### PR TITLE
Updates to adapt with cuVS-Java API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ The cuVS library is plugged in as a new `KnnVectorFormat` via a custom codec.
 mvn clean compile package
 ```
 
+### Run Tests
+```sh
+export LD_LIBRARY_PATH={ PATH TO YOUR LOCAL libcuvs_c.so }:$LD_LIBRARY_PATH && mvn clean test
+```
+
 The artifacts would be built and available in the target/ folder.
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ The cuVS library is plugged in as a new `KnnVectorFormat` via a custom codec.
 ```sh
 mvn clean compile package
 ```
+The artifacts would be built and available in the target / folder.
 
 ### Run Tests
 ```sh
 export LD_LIBRARY_PATH={ PATH TO YOUR LOCAL libcuvs_c.so }:$LD_LIBRARY_PATH && mvn clean test
 ```
-
-The artifacts would be built and available in the target/ folder.
 
 > [!NOTE]
 > The code style format is automatically enforced (including the missing license header, if any) using the [Spotless maven plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven). This currently happens in the maven's `validate` stage.

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
     <dependency>
       <groupId>com.nvidia.cuvs</groupId>
       <artifactId>cuvs-java</artifactId>
-      <version>25.08.0</version>
+      <!-- Note: This is temporary measure (artifact coming from https://maven.searchscale.com/snapshots, for now) and will get updated in subsequent PRs. -->
+      <version>25.8.0-4f53f-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSCodec.java
@@ -34,6 +34,7 @@ public class CuVSCodec extends FilterCodec {
     super(name, delegate);
     KnnVectorsFormat format;
     try {
+      // TODO: Remove this hard coded values.
       format = new CuVSVectorsFormat(1, 128, 64, IndexType.CAGRA);
       setKnnFormat(format);
     } catch (LibraryException ex) {

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSSegmentFile.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSSegmentFile.java
@@ -39,11 +39,6 @@ import java.util.zip.ZipOutputStream;
   protected Logger log = Logger.getLogger(getClass().getName());
 
   public void addFile(String name, byte[] bytes) throws IOException {
-    /*log.info(
-    "Writing the file: "
-        + name
-        + ", size="
-        + bytes.length);*/
     ZipEntry indexFileZipEntry = new ZipEntry(name);
     zos.putNextEntry(indexFileZipEntry);
     zos.write(bytes, 0, bytes.length);

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsReader.java
@@ -352,13 +352,13 @@ public class CuVSVectorsReader extends KnnVectorsReader {
     if (knnCollector.k() <= 1024 && cuvsIndex.getCagraIndex() != null) {
       // log.info("searching cagra index");
       CagraSearchParams searchParams =
-          new CagraSearchParams.Builder(resources)
+          new CagraSearchParams.Builder()
               .withItopkSize(topK) // TODO: params
               .withSearchWidth(1)
               .build();
 
       var query =
-          new CagraQuery.Builder()
+          new CagraQuery.Builder(resources)
               .withTopK(topK)
               .withSearchParams(searchParams)
               // we don't use ord to doc mapping, https://github.com/rapidsai/cuvs/issues/699
@@ -381,7 +381,9 @@ public class CuVSVectorsReader extends KnnVectorsReader {
       assert bruteforceIndex != null;
       // log.info("searching brute index, with actual topK=" + topK);
       var queryBuilder =
-          new BruteForceQuery.Builder().withQueryVectors(new float[][] {target}).withTopK(topK);
+          new BruteForceQuery.Builder(resources)
+              .withQueryVectors(new float[][] {target})
+              .withTopK(topK);
       BruteForceQuery query = queryBuilder.build();
 
       List<Map<Integer, Float>> searchResult = null;

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsReader.java
@@ -361,8 +361,6 @@ public class CuVSVectorsReader extends KnnVectorsReader {
           new CagraQuery.Builder(resources)
               .withTopK(topK)
               .withSearchParams(searchParams)
-              // we don't use ord to doc mapping, https://github.com/rapidsai/cuvs/issues/699
-              .withMapping(null)
               .withQueryVectors(new float[][] {target})
               .build();
 

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsReader.java
@@ -334,7 +334,6 @@ public class CuVSVectorsReader extends KnnVectorsReader {
     }
 
     var fieldNumber = fieldInfos.fieldInfo(field).number;
-    // log.info("fieldNumber=" + fieldNumber + ", fieldEntry.count()=" + fieldEntry.count());
 
     CuVSIndex cuvsIndex = cuvsIndices.get(fieldNumber);
     if (cuvsIndex == null) {
@@ -350,7 +349,6 @@ public class CuVSVectorsReader extends KnnVectorsReader {
 
     Map<Integer, Float> result;
     if (knnCollector.k() <= 1024 && cuvsIndex.getCagraIndex() != null) {
-      // log.info("searching cagra index");
       CagraSearchParams searchParams =
           new CagraSearchParams.Builder()
               .withItopkSize(topK) // TODO: params
@@ -377,7 +375,6 @@ public class CuVSVectorsReader extends KnnVectorsReader {
     } else {
       BruteForceIndex bruteforceIndex = cuvsIndex.getBruteforceIndex();
       assert bruteforceIndex != null;
-      // log.info("searching brute index, with actual topK=" + topK);
       var queryBuilder =
           new BruteForceQuery.Builder(resources)
               .withQueryVectors(new float[][] {target})

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsWriter.java
@@ -31,8 +31,8 @@ import com.nvidia.cuvs.BruteForceIndexParams;
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CagraIndexParams;
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
+import com.nvidia.cuvs.CuVSMatrix;
 import com.nvidia.cuvs.CuVSResources;
-import com.nvidia.cuvs.Dataset;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -61,7 +61,10 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
 
-/** KnnVectorsWriter for CuVS, responsible for merge and flush of vectors into GPU */
+/**
+ * KnnVectorsWriter for CuVS, responsible for merge and flush of vectors into
+ * GPU
+ */
 public class CuVSVectorsWriter extends KnnVectorsWriter {
 
   private static final long SHALLOW_RAM_BYTES_USED = shallowSizeOfInstance(CuVSVectorsWriter.class);
@@ -199,7 +202,8 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     }
     // var minIntGraphDegree = Math.min(intGraphDegree, size - 1);
     // var minGraphDegree = Math.min(graphDegree, minIntGraphDegree);
-    // log.info(indexMsg(size, intGraphDegree, minIntGraphDegree, graphDegree, minGraphDegree));
+    // log.info(indexMsg(size, intGraphDegree, minIntGraphDegree, graphDegree,
+    // minGraphDegree));
 
     return new CagraIndexParams.Builder()
         .withNumWriterThreads(cuvsWriterThreads)
@@ -219,11 +223,11 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     }
   }
 
-  private void writeCagraIndex(OutputStream os, Dataset dataset) throws Throwable {
+  private void writeCagraIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
     if (dataset.size() < 2) {
       throw new IllegalArgumentException(dataset.size() + " vectors, less than min [2] required");
     }
-    CagraIndexParams params = cagraIndexParams(dataset.size());
+    CagraIndexParams params = cagraIndexParams((int) dataset.size());
     long startTime = System.nanoTime();
     var index =
         CagraIndex.newBuilder(resources).withDataset(dataset).withIndexParams(params).build();
@@ -234,10 +238,11 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     index.destroyIndex();
   }
 
-  private void writeBruteForceIndex(OutputStream os, Dataset dataset) throws Throwable {
+  private void writeBruteForceIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
     BruteForceIndexParams params =
         new BruteForceIndexParams.Builder()
-            .withNumWriterThreads(32) // TODO: Make this configurable later.
+            .withNumWriterThreads(32) // TODO: Make this
+            // configurable later.
             .build();
     long startTime = System.nanoTime();
     var index =
@@ -248,11 +253,11 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     index.destroyIndex();
   }
 
-  private void writeHNSWIndex(OutputStream os, Dataset dataset) throws Throwable {
+  private void writeHNSWIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
     if (dataset.size() < 2) {
       throw new IllegalArgumentException(dataset.size() + " vectors, less than min [2] required");
     }
-    CagraIndexParams indexParams = cagraIndexParams(dataset.size());
+    CagraIndexParams indexParams = cagraIndexParams((int) dataset.size());
     long startTime = System.nanoTime();
     var index =
         CagraIndex.newBuilder(resources).withDataset(dataset).withIndexParams(indexParams).build();
@@ -278,9 +283,11 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
   private void writeField(CuVSFieldWriter fieldData) throws IOException {
     // TODO: Argh! https://github.com/rapidsai/cuvs/issues/698
     List<float[]> vectors = fieldData.getVectors();
-    Dataset dataset = Dataset.create(vectors.size(), fieldData.fieldInfo().getVectorDimension());
-    for (float[] vec : vectors) dataset.addVector(vec);
-    writeFieldInternal(fieldData.fieldInfo(), dataset);
+    CuVSMatrix.Builder builder =
+        CuVSMatrix.builder(
+            vectors.size(), fieldData.fieldInfo().getVectorDimension(), CuVSMatrix.DataType.FLOAT);
+    for (float[] vec : vectors) builder.addVector(vec);
+    writeFieldInternal(fieldData.fieldInfo(), builder.build());
   }
 
   private void writeSortingField(CuVSFieldWriter fieldData, Sorter.DocMap sortMap)
@@ -291,16 +298,19 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     mapOldOrdToNewOrd(oldDocsWithFieldSet, sortMap, null, new2OldOrd, null);
 
     float[][] oldVectors = fieldData.getVectors().toArray(float[][]::new);
-    Dataset dataset =
-        Dataset.create(fieldData.getVectors().size(), fieldData.fieldInfo().getVectorDimension());
+    CuVSMatrix.Builder builder =
+        CuVSMatrix.builder(
+            fieldData.getVectors().size(),
+            fieldData.fieldInfo().getVectorDimension(),
+            CuVSMatrix.DataType.FLOAT);
     for (int i = 0; i < oldVectors.length; i++) {
       float[] vec = oldVectors[new2OldOrd[i]];
-      dataset.addVector(vec);
+      builder.addVector(vec);
     }
-    writeFieldInternal(fieldData.fieldInfo(), dataset);
+    writeFieldInternal(fieldData.fieldInfo(), builder.build());
   }
 
-  private void writeFieldInternal(FieldInfo fieldInfo, Dataset dataset) throws IOException {
+  private void writeFieldInternal(FieldInfo fieldInfo, CuVSMatrix dataset) throws IOException {
     if (dataset.size() == 0) {
       writeEmpty(fieldInfo);
       return;
@@ -360,7 +370,7 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
 
       writeMeta(
           fieldInfo,
-          dataset.size(),
+          (int) dataset.size(),
           cagraIndexOffset,
           cagraIndexLength,
           bruteForceIndexOffset,
@@ -424,8 +434,11 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     handleThrowable(t);
   }
 
-  /** Copies the vector values into dst. Returns the actual number of vectors copied. */
-  private static int getVectorData(FloatVectorValues floatVectorValues, Dataset dataset)
+  /**
+   * Copies the vector values into dst. Returns the actual number of vectors
+   * copied.
+   */
+  private static int getVectorData(FloatVectorValues floatVectorValues, CuVSMatrix.Builder builder)
       throws IOException {
     DocsWithFieldSet docsWithField = new DocsWithFieldSet();
     int count = 0;
@@ -433,7 +446,7 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
       assert iter.index() == count;
       // dst[iter.index()] = floatVectorValues.vectorValue(iter.index());
-      dataset.addVector(floatVectorValues.vectorValue(iter.index())); // is this correct?
+      builder.addVector(floatVectorValues.vectorValue(iter.index())); // is this correct?
       docsWithField.add(docV);
       count++;
     }
@@ -452,9 +465,11 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
           };
 
       // Also will be replaced with the cuVS merge api
-      Dataset dataset = Dataset.create(mergedVectorValues.size(), mergedVectorValues.dimension());
-      getVectorData(mergedVectorValues, dataset);
-      writeFieldInternal(fieldInfo, dataset);
+      CuVSMatrix.Builder builder =
+          CuVSMatrix.builder(
+              mergedVectorValues.size(), mergedVectorValues.dimension(), CuVSMatrix.DataType.FLOAT);
+      getVectorData(mergedVectorValues, builder);
+      writeFieldInternal(fieldInfo, builder.build());
     } catch (Throwable t) {
       handleThrowable(t);
     }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVSVectorsWriter.java
@@ -200,10 +200,6 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
       // https://github.com/rapidsai/cuvs/issues/666
       throw new IllegalArgumentException("cagra index must be greater than 2");
     }
-    // var minIntGraphDegree = Math.min(intGraphDegree, size - 1);
-    // var minGraphDegree = Math.min(graphDegree, minIntGraphDegree);
-    // log.info(indexMsg(size, intGraphDegree, minIntGraphDegree, graphDegree,
-    // minGraphDegree));
 
     return new CagraIndexParams.Builder()
         .withNumWriterThreads(cuvsWriterThreads)
@@ -359,15 +355,6 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
         hnswIndexLength = cuvsIndex.getFilePointer() - hnswIndexOffset;
       }
 
-      // StringBuilder sb = new StringBuilder("writeField ");
-      // sb.append(": fieldInfo.name=").append(fieldInfo.name);
-      // sb.append(", fieldInfo.number=").append(fieldInfo.number);
-      // sb.append(", size=").append(vectors.length);
-      // sb.append(", cagraIndexLength=").append(cagraIndexLength);
-      // sb.append(", bruteForceIndexLength=").append(bruteForceIndexLength);
-      // sb.append(", hnswIndexLength=").append(hnswIndexLength);
-      // log.info(sb.toString());
-
       writeMeta(
           fieldInfo,
           (int) dataset.size(),
@@ -445,7 +432,6 @@ public class CuVSVectorsWriter extends KnnVectorsWriter {
     KnnVectorValues.DocIndexIterator iter = floatVectorValues.iterator();
     for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
       assert iter.index() == count;
-      // dst[iter.index()] = floatVectorValues.vectorValue(iter.index());
       builder.addVector(floatVectorValues.vectorValue(iter.index())); // is this correct?
       docsWithField.add(docV);
       count++;

--- a/src/main/java/com/nvidia/cuvs/lucene/FilterCuVSProvider.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/FilterCuVSProvider.java
@@ -17,10 +17,13 @@ package com.nvidia.cuvs.lucene;
 
 import com.nvidia.cuvs.BruteForceIndex;
 import com.nvidia.cuvs.CagraIndex;
+import com.nvidia.cuvs.CuVSMatrix;
+import com.nvidia.cuvs.CuVSMatrix.Builder;
+import com.nvidia.cuvs.CuVSMatrix.DataType;
 import com.nvidia.cuvs.CuVSResources;
-import com.nvidia.cuvs.Dataset;
 import com.nvidia.cuvs.HnswIndex;
 import com.nvidia.cuvs.spi.CuVSProvider;
+import java.lang.invoke.MethodHandle;
 import java.nio.file.Path;
 
 /*package-private*/ class FilterCuVSProvider implements CuVSProvider {
@@ -65,7 +68,33 @@ import java.nio.file.Path;
   }
 
   @Override
-  public Dataset newDataset(int arg0, int arg1) throws UnsupportedOperationException {
-    return delegate.newDataset(arg0, arg1);
+  public Builder newMatrixBuilder(int size, int dimensions, DataType dataType) {
+    return delegate.newMatrixBuilder(size, dimensions, dataType);
+  }
+
+  @Override
+  public MethodHandle newNativeMatrixBuilder() {
+    return delegate.newNativeMatrixBuilder();
+  }
+
+  @Override
+  public CuVSMatrix newMatrixFromArray(float[][] vectors) {
+    return delegate.newMatrixFromArray(vectors);
+  }
+
+  @Override
+  public CuVSMatrix newMatrixFromArray(int[][] vectors) {
+    return delegate.newMatrixFromArray(vectors);
+  }
+
+  @Override
+  public CuVSMatrix newMatrixFromArray(byte[][] vectors) {
+    return delegate.newMatrixFromArray(vectors);
+  }
+
+  @Override
+  public com.nvidia.cuvs.TieredIndex.Builder newTieredIndexBuilder(CuVSResources cuVSResources)
+      throws UnsupportedOperationException {
+    return delegate.newTieredIndexBuilder(cuVSResources);
   }
 }

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -15,4 +15,4 @@
 
 org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat
 org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat
-com.searchscale.lucene.vectorsearch.CuVSVectorsFormat
+com.nvidia.cuvs.lucene.CuVSVectorsFormat

--- a/src/test/java/com/nvidia/cuvs/lucene/TestCuVS.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestCuVS.java
@@ -128,7 +128,6 @@ public class TestCuVS extends LuceneTestCase {
     log.info("Query size: " + numQueries + "x" + queries[0].length);
     log.info("TopK: " + topK);
 
-    // Query query = new CuVSKnnFloatVectorQuery("vector", queries[0], topK, topK, 1);
     Query query = new KnnFloatVectorQuery("vector", queries[0], topK);
     int correct[] = new int[topK];
     for (int i = 0; i < topK; i++) correct[i] = expected.get(0).get(i);

--- a/src/test/java/com/nvidia/cuvs/lucene/TestCuVSVectorsFormat.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestCuVSVectorsFormat.java
@@ -28,10 +28,12 @@ import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 
 public class TestCuVSVectorsFormat extends BaseKnnVectorsFormatTestCase {
 
@@ -126,4 +128,40 @@ public class TestCuVSVectorsFormat extends BaseKnnVectorsFormatTestCase {
       }
     }
   }
+
+  @Override
+  // Overriding this method from superclass for the tests to only use float vector encoding
+  protected VectorEncoding randomVectorEncoding() {
+    return VectorEncoding.FLOAT32;
+  }
+
+  @Ignore
+  @Override
+  // Ignoring this test from superclass as we do not support byte vectors
+  public void testByteVectorScorerIteration() {}
+
+  @Ignore
+  @Override
+  // Ignoring this test from superclass as we do not support byte vectors
+  public void testEmptyByteVectorData() {}
+
+  @Ignore
+  @Override
+  // Ignoring this test from superclass as we do not support byte vectors
+  public void testMergingWithDifferentByteKnnFields() {}
+
+  @Ignore
+  @Override
+  // Ignoring this test from superclass as we do not support byte vectors
+  public void testMismatchedFields() {}
+
+  @Ignore
+  @Override
+  // Ignoring this test from superclass as we do not support byte vectors
+  public void testRandomBytes() {}
+
+  @Ignore
+  @Override
+  // Ignoring this test from superclass as we do not support byte vectors
+  public void testSortedIndexBytes() {}
 }

--- a/src/test/java/com/nvidia/cuvs/lucene/TestCuVSVectorsFormat.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestCuVSVectorsFormat.java
@@ -45,9 +45,6 @@ public class TestCuVSVectorsFormat extends BaseKnnVectorsFormatTestCase {
   @Override
   protected Codec getCodec() {
     return TestUtil.alwaysKnnVectorsFormat(new CuVSVectorsFormat());
-    // For convenience, to sanitize the test code, one can comment out
-    // the supported check and use another format, e.g.
-    // return TestUtil.alwaysKnnVectorsFormat(new Lucene99HnswVectorsFormat());
   }
 
   public void testMergeTwoSegsWithASingleDocPerSeg() throws Exception {

--- a/src/test/java/com/nvidia/cuvs/lucene/TestIndexOutputOutputStream.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestIndexOutputOutputStream.java
@@ -35,7 +35,6 @@ public class TestIndexOutputOutputStream extends LuceneTestCase {
 
       try (var indexIn = dir.openInput("test", IOContext.DEFAULT)) {
         var in = new IndexInputInputStream(indexIn);
-        // assertEquals(0x56, in.read());
         byte[] ba = new byte[6];
         assertEquals(6, in.read(ba));
         assertArrayEquals(new byte[] {0x56, 0x10, 0x11, 0x12, 0x13, 0x14}, ba);
@@ -78,6 +77,7 @@ public class TestIndexOutputOutputStream extends LuceneTestCase {
       }
 
       try (var indexIn = dir.openInput("test", IOContext.DEFAULT)) {
+        // TODO: close this stream properly in a subsequent PR.
         var in = new IndexInputInputStream(indexIn);
         int i = 0;
         while (i < data.length) {


### PR DESCRIPTION
Fixes #5 

Main changes in this PR:
- Adapt to the cuVS-Java API updates: Mainly replace the use of `Dataset` with the new `CuVSMatrix`
- Disable the tests that use byte vector encoding, as we do not support it.