### PR TITLE
simplify build scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,10 @@ repos:
                   CMakeLists_standalone[.]txt$|
                   meta[.]yaml$
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.19.2
+        rev: v1.20.0
         hooks:
             - id: rapids-dependency-file-generator
-              args: ["--clean"]
+              args: ["--clean", "--warn-all", "--strict"]
       - repo: https://github.com/shellcheck-py/shellcheck-py
         rev: v0.11.0.1
         hooks:

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -32,13 +32,6 @@ set -u
 
 rapids-print-env
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
 rapids-logger "Run Java build"
 
 bash ./build.sh "${EXTRA_BUILD_ARGS[@]}"
-
-rapids-logger "Build script exiting with value: $EXITCODE"
-exit ${EXITCODE}

--- a/ci/test_java.sh
+++ b/ci/test_java.sh
@@ -3,10 +3,6 @@
 
 set -euo pipefail
 
-EXITCODE=0
-trap "EXITCODE=1" ERR
-set +e
-
 rapids-logger "Check GPU usage"
 nvidia-smi
 
@@ -15,6 +11,3 @@ rapids-logger "Run Java build and tests"
 # TODO: switch to installing pre-built artifacts instead of rebuilding in test jobs
 #       ref: https://github.com/rapidsai/cuvs/issues/868
 ci/build_java.sh --run-java-tests
-
-rapids-logger "Test script exiting with value: $EXITCODE"
-exit ${EXITCODE}


### PR DESCRIPTION
* updates `rapids-dependency-file-generator`, to pull in changes from https://github.com/rapidsai/dependency-file-generator/pull/163
* removes unnecessary error-trapping in shell scripts