### PR TITLE
Fix `cuvs-lucene` Github artifact publication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,6 @@ jobs:
       date: ${{ inputs.date }}
       container_image: "rapidsai/ci-conda:25.10-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
       script: "ci/build_java.sh"
-      file_to_upload: "java/cuvs-java/target/"
+      file_to_upload: "target/"
       artifact-name: "cuvs-lucene-cuda${{ matrix.cuda_version }}"
       sha: ${{ inputs.sha }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -75,7 +75,7 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:25.10-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
       script: "ci/test_java.sh"
-      file_to_upload: "java/cuvs-java/target/"
+      file_to_upload: "target/"
       artifact-name: "cuvs-lucene-cuda${{ matrix.cuda_version }}"
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.


### PR DESCRIPTION
This commit fixes the publication of cuvs-lucene artifacts to Github.

The Github actions build-logs indicate that while the JAR is built correctly, it doesn't seem to be uploaded properly as a Github artifact. It appears to be the result of a minor typo in the artifact's base dir.

This commit fixes the typo, and allows the artifact to be published.