### PR TITLE
Add support to build the sources jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,19 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
         <executions>


### PR DESCRIPTION
This commit adds support to build the `cuvs-lucene` source jar.  Both `sources` and `javadoc` jar artifacts are required for publication to Maven Central.