### PR TITLE
Use strict priority in CI conda tests

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -9,6 +9,9 @@ rapids-logger "Create checks conda environment"
 # shellcheck disable=SC1091
 . /opt/conda/etc/profile.d/conda.sh
 
+rapids-logger "Configuring conda strict channel priority"
+conda config --set channel_priority strict
+
 rapids-dependency-file-generator \
   --output conda \
   --file-key checks \


### PR DESCRIPTION
## Description
This PR sets conda to use `strict` priority in CI tests.

Mixing channel priority is frequently a cause of unexpected errors. Our CI jobs should always use strict priority in order to enforce that conda packages come from local channels with the artifacts built in CI, not mixing with older nightly artifacts from the `rapidsai-nightly` channel or other sources.

xref: https://github.com/rapidsai/build-planning/issues/14
