### PR TITLE
Fix groupId in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ ARGS="$*"
 NUMARGS=$#
 
 VERSION="25.12.0" # Note: The version is updated automatically when ci/release/update-version.sh is invoked
-GROUP_ID="com.nvidia.cuvs"
+GROUP_ID="com.nvidia.cuvs.lucene"
 
 function hasArg {
     (( NUMARGS != 0 )) && (echo " ${ARGS} " | grep -q " $1 ")


### PR DESCRIPTION
PR to fix the `groupId` in `build.sh` - to match with `groupId` in `pom.xml`.