### PR TITLE
Fix spotless plugin configuration for examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -80,9 +80,6 @@
                     <reflowLongStrings>true</reflowLongStrings>
                     <formatJavadoc>false</formatJavadoc>
                 </googleJavaFormat>
-                <licenseHeader>
-                    <file>../license-header.txt</file>
-                </licenseHeader>
             </java>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fixes the spotless plugin configuration - remove license header enforcement, part of #82, for the examples maven sub-project.  