### PR TITLE
build and test against CUDA 13.1.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.0.2'
+          - '13.1.0'
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.0.2'
+          - '13.1.0'
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.0.2'
+          - '13.1.0'
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-version=13.0
+- cuda-version=13.1
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev
@@ -17,4 +17,4 @@ dependencies:
 - maven
 - ninja
 - openjdk=22.*
-name: all_cuda-130_arch-aarch64
+name: all_cuda-131_arch-aarch64

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -8,7 +8,7 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-version=13.0
+- cuda-version=13.1
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev
@@ -17,4 +17,4 @@ dependencies:
 - maven
 - ninja
 - openjdk=22.*
-name: all_cuda-130_arch-x86_64
+name: all_cuda-131_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator
@@ -6,7 +6,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.9", "13.0"]
+      cuda: ["12.9", "13.1"]
       arch: [x86_64, aarch64]
     includes:
       - cuda
@@ -59,6 +59,10 @@ dependencies:
               cuda: "13.0"
             packages:
               - cuda-version=13.0
+          - matrix:
+              cuda: "13.1"
+            packages:
+              - cuda-version=13.1
   cuda:
     common:
       - output_types: [conda]

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ cd ..
 
 Then do:
 ```sh
-docker run --rm --gpus all --pull=always --volume $PWD:$PWD --workdir $PWD -it rapidsai/ci-conda:26.02-cuda13.0.2-ubuntu24.04-py3.13
+docker run --rm --gpus all --pull=always --volume $PWD:$PWD --workdir $PWD -it rapidsai/ci-conda:26.02-cuda13.1.0-ubuntu24.04-py3.13
 ```
 
 Inside the docker container (and in the `cuvs-lucene's` root directory) do:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/236

Tests that CI here will work with the changes from https://github.com/rapidsai/shared-workflows/pull/483,
switches CUDA 13 builds to CUDA 13.1.0 and adds some CUDA 13.1.0 test jobs.
