### PR TITLE
Fix for result returned was not in topk

### DIFF
--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.nvidia.cuvs.lucene;
@@ -526,7 +526,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
     for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
       int ordinal = iter.index();
       float[] vector = mergedVectorValues.vectorValue(ordinal);
-      res.add(vector);
+      res.add(vector.clone());
     }
     return res;
   }

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.nvidia.cuvs.lucene;
@@ -737,7 +737,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
     KnnVectorValues.DocIndexIterator iter = mergedVectorValues.iterator();
     for (int docV = iter.nextDoc(); docV != NO_MORE_DOCS; docV = iter.nextDoc()) {
       float[] vector = mergedVectorValues.vectorValue(iter.index());
-      vectors.add(vector);
+      vectors.add(vector.clone());
     }
     return vectors;
   }


### PR DESCRIPTION
Issue:
We have noticed a few occurrences of test failures complaining of missing topK values in the results. A deeper level of debugging made me realize that this was happening in specific merge cases due to a silly bug in the merge code path. Essentially, while passing the collection of vectors down the layers, the vectors were getting messed up, causing a corrupt merged segment.

Fix:
This simple fix corrects the vectors in the collection passed down the layer in the merge code path.

Fixes #92 