### PR TITLE
Code improvements - Index and search on the GPU API

### DIFF
--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUSearchCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUSearchCodec.java
@@ -12,7 +12,7 @@ import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 
 /**
- * cuVS based codec for GPU based vector search
+ * cuVS based codec for GPU based vector search that enables both - indexing and search on the GPU.
  * cuVS serialization formats are in experimental phase and hence backward compatibility cannot be guaranteed.
  *
  * @since 25.10
@@ -24,7 +24,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
   private KnnVectorsFormat format;
 
   /**
-   * Default constructor for {@link CuVS2510GPUSearchCodec}
+   * Default constructor for {@link CuVS2510GPUSearchCodec}.
    *
    * @throws Exception
    */
@@ -34,7 +34,8 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
   }
 
   /**
-   * Initialize {@link CuVS2510GPUSearchCodec} with default parameter values.
+   * Initialize {@link CuVS2510GPUSearchCodec} with an instance of {@link GPUSearchParams}
+   * having default parameter values.
    *
    * @param name the name of the codec
    * @param delegate the delegate codec
@@ -45,16 +46,22 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
   }
 
   /**
-   * Initialize the codec with custom parameter values.
+   * Initialize the codec with an instance of {@link GPUSearchParams} having either default
+   * or overridden parameter values.
    *
    * @param params An instance of {@link GPUSearchParams}
-   * @throws Exception Exception raised when initializing the codec.
+   * @throws Exception Exception raised when initializing the codec
    */
   public CuVS2510GPUSearchCodec(GPUSearchParams params) throws Exception {
     this(NAME, LuceneProvider.getCodec("101"));
     initializeFormat(params);
   }
 
+  /**
+   * Initialize the {@link CuVS2510GPUVectorsFormat} instance using {@link GPUSearchParams}.
+   *
+   * @param params an instance of {@link GPUSearchParams}
+   */
   private void initializeFormat(GPUSearchParams params) {
     try {
       format = new CuVS2510GPUVectorsFormat(params);
@@ -67,7 +74,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
   }
 
   /**
-   * Get the configured {@link KnnVectorsFormat}
+   * Get the configured {@link KnnVectorsFormat}.
    *
    * @return the instance of the {@link KnnVectorsFormat}
    */
@@ -77,7 +84,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
   }
 
   /**
-   * Set the {@link KnnVectorsFormat}
+   * Set the {@link KnnVectorsFormat}.
    *
    * @param format the {@link KnnVectorsFormat} to set
    */

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
@@ -10,6 +10,7 @@ import com.nvidia.cuvs.LibraryException;
 import java.io.IOException;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
+import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
 import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
 import org.apache.lucene.index.SegmentReadState;
@@ -56,7 +57,7 @@ public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
   }
 
   /**
-   * Initializes the {@link CuVS2510GPUVectorsFormat} with the given threads, graph degree, etc.
+   * Initializes the {@link CuVS2510GPUVectorsFormat} with an instance of {@link GPUSearchParams}.
    *
    * @param gpuSearchParams An instance of {@link GPUSearchParams}
    * @throws LibraryException if the native library fails to load
@@ -67,17 +68,17 @@ public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
   }
 
   /**
-   * Returns a {@link CuVS2510GPUVectorsWriter} to write the vectors to the index.
+   * Returns a KnnVectorsReader instance to write the vectors to the index.
    */
   @Override
-  public CuVS2510GPUVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
+  public KnnVectorsWriter fieldsWriter(SegmentWriteState state) throws IOException {
     assertIsSupported();
     var flatWriter = FLAT_VECTORS_FORMAT.fieldsWriter(state);
     return new CuVS2510GPUVectorsWriter(state, gpuSearchParams, flatWriter);
   }
 
   /**
-   * Returns a KnnVectorsReader to read the vectors from the index.
+   * Returns a KnnVectorsReader instance to read the vectors from the index.
    */
   @Override
   public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
@@ -27,17 +27,17 @@ public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
   @SuppressWarnings("unused")
   private static final Logger log = Logger.getLogger(CuVS2510GPUVectorsFormat.class.getName());
 
-  private static final int maxDimensions = 4096;
+  private static final int MAX_DIMENSIONS = 4096;
   private static final LuceneProvider LUCENE_PROVIDER;
   private static final FlatVectorsFormat FLAT_VECTORS_FORMAT;
   private GPUSearchParams gpuSearchParams;
 
-  static final String CUVS_META_CODEC_NAME = "Lucene102CuVSVectorsFormatMeta";
-  static final String CUVS_META_CODEC_EXT = "vemc";
-  static final String CUVS_INDEX_CODEC_NAME = "Lucene102CuVSVectorsFormatIndex";
-  static final String CUVS_INDEX_EXT = "vcag";
-  static final int VERSION_START = 0;
-  static final int VERSION_CURRENT = VERSION_START;
+  public static final String CUVS_META_CODEC_NAME = "Lucene102CuVSVectorsFormatMeta";
+  public static final String CUVS_META_CODEC_EXT = "vemc";
+  public static final String CUVS_INDEX_CODEC_NAME = "Lucene102CuVSVectorsFormatIndex";
+  public static final String CUVS_INDEX_EXT = "vcag";
+  public static final int VERSION_START = 0;
+  public static final int VERSION_CURRENT = VERSION_START;
 
   static {
     try {
@@ -93,6 +93,6 @@ public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
    */
   @Override
   public int getMaxDimensions(String fieldName) {
-    return maxDimensions;
+    return MAX_DIMENSIONS;
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
@@ -8,7 +8,6 @@ import static com.nvidia.cuvs.lucene.ThreadLocalCuVSResourcesProvider.assertIsSu
 
 import com.nvidia.cuvs.LibraryException;
 import java.io.IOException;
-import java.util.logging.Logger;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.hnsw.DefaultFlatVectorScorer;
@@ -24,13 +23,9 @@ import org.apache.lucene.index.SegmentWriteState;
  */
 public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
 
-  @SuppressWarnings("unused")
-  private static final Logger log = Logger.getLogger(CuVS2510GPUVectorsFormat.class.getName());
-
   private static final int MAX_DIMENSIONS = 4096;
   private static final LuceneProvider LUCENE_PROVIDER;
   private static final FlatVectorsFormat FLAT_VECTORS_FORMAT;
-  private GPUSearchParams gpuSearchParams;
 
   public static final String CUVS_META_CODEC_NAME = "Lucene102CuVSVectorsFormatMeta";
   public static final String CUVS_META_CODEC_EXT = "vemc";
@@ -38,6 +33,8 @@ public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
   public static final String CUVS_INDEX_EXT = "vcag";
   public static final int VERSION_START = 0;
   public static final int VERSION_CURRENT = VERSION_START;
+
+  private GPUSearchParams gpuSearchParams;
 
   static {
     try {

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -24,6 +24,7 @@ import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.codecs.CodecUtil;
@@ -359,7 +360,8 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    */
   @Override
   public void checkIntegrity() throws IOException {
-    // TODO: Pending implementation
+    flatVectorsReader.checkIntegrity();
+    CodecUtil.checksumEntireFile(cuvsIndexInput);
   }
 
   /**
@@ -381,7 +383,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   }
 
   /** Native float to float function */
-  public interface FloatToFloatFunction {
+  private interface FloatToFloatFunction {
     float apply(float v);
   }
 
@@ -421,16 +423,19 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
     if (acceptDocs != null) {
       mask = new BitSet[1]; // As there is only one query "target"
       mask[0] = new BitSet(acceptedOrds.length());
+      /*
+       * Need to find if there is a better alternative to the below
+       * in subsequent code improvement iterations.
+       */
       for (int i = 0; i < acceptedOrds.length(); i++) {
         if (acceptedOrds.get(i)) {
           mask[0].set(i);
         }
       }
-      topK = Math.min(knnCollector.k() + 5, mask[0].cardinality());
+      topK = Math.min(knnCollector.k() + 10, mask[0].cardinality());
     }
 
     try {
-      Map<Integer, Float> result;
       List<Map<Integer, Float>> searchResult = null;
       if (knnCollector.k() <= 1024 && cuvsIndex.getCagraIndex() != null) {
         CagraSearchParams searchParams;
@@ -488,13 +493,12 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
 
       // List expected to have only one entry because of single query "target".
       assert searchResult.size() == 1;
-      result = searchResult.getFirst();
 
       final IntToIntFunction ordToDocFunction = (IntToIntFunction) rawValues::ordToDoc;
       final FloatToFloatFunction scoreCorrectionFunction =
           getScoreNormalizationFunc(fieldEntry.similarityFunction);
 
-      for (var entry : result.entrySet()) {
+      for (Entry<Integer, Float> entry : searchResult.getFirst().entrySet()) {
         int ord = entry.getKey();
         float score = entry.getValue();
         if (knnCollector.earlyTerminated()) {
@@ -503,7 +507,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
         if (ord < 0) {
           continue;
         }
-        assert ord >= 0 : "unexpected ord: " + ord;
         float correctedScore = scoreCorrectionFunction.apply(score);
         int doc = ordToDocFunction.apply(ord);
         knnCollector.incVisitedCount(1);

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -398,13 +398,13 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   @Override
   public void search(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs)
       throws IOException {
-    FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
+    var fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
     if (fieldEntry.count() == 0 || knnCollector.k() == 0) {
       return;
     }
 
     var fieldNumber = fieldInfos.fieldInfo(field).number;
-    GPUIndex cuvsIndex = cuvsIndices.get(fieldNumber);
+    GPUIndex cuvsIndex = cuvsIndices != null ? cuvsIndices.get(fieldNumber) : null;
     if (cuvsIndex == null) {
       throw new IllegalStateException("Index not found for field:" + field);
     }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -112,7 +112,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
       }
       var ioContext = state.context.withReadAdvice(ReadAdvice.SEQUENTIAL);
       cuvsIndexInput = openCuVSInput(state, versionMeta, ioContext);
-
       // Detect if an instance of this reader is getting opened when there is a merge call.
       boolean isMergeCall = false;
       for (StackTraceElement s : Thread.currentThread().getStackTrace()) {
@@ -128,7 +127,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
       } else {
         cuvsIndices = null;
       }
-
       success = true;
     } finally {
       if (success == false) {
@@ -373,7 +371,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   }
 
   /**
-   * Returns the FloatVectorValues for the given field.
+   * Returns the ByteVectorValues for the given field.
    *
    * This is not supported.
    */
@@ -418,14 +416,17 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
     final FloatVectorValues rawValues = flatVectorsReader.getFloatVectorValues(field);
     final Bits acceptedOrds = rawValues.getAcceptOrds(acceptDocs);
     BitSet[] mask = null;
+    int maskLength = 0;
     int topK = knnCollector.k();
 
     if (acceptDocs != null) {
       mask = new BitSet[1]; // As there is only one query "target"
       mask[0] = new BitSet(acceptedOrds.length());
       /*
-       * Need to find if there is a better alternative to the below
-       * in subsequent code improvement iterations.
+       * Need to find if there is a better alternative for below loop
+       * in subsequent code improvement iterations. This is needed as
+       * there is a difference between Lucene's Bits "acceptDocs" and
+       * what our API accepts.
        */
       for (int i = 0; i < acceptedOrds.length(); i++) {
         if (acceptedOrds.get(i)) {
@@ -433,6 +434,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
         }
       }
       topK = Math.min(knnCollector.k() + 10, mask[0].cardinality());
+      maskLength = mask[0].length();
     }
 
     try {
@@ -453,20 +455,21 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
         CagraIndex cagraIndex = cuvsIndex.getCagraIndex();
         assert cagraIndex != null;
         CagraQuery query = null;
+        CuVSMatrix queryVector = CuVSMatrix.ofArray(new float[][] {target});
         if (acceptDocs != null) {
           query =
               new CagraQuery.Builder(getCuVSResourcesInstance())
                   .withTopK(topK)
                   .withSearchParams(searchParams)
-                  .withQueryVectors(CuVSMatrix.ofArray(new float[][] {target}))
-                  .withPrefilter(mask[0], mask[0].length())
+                  .withQueryVectors(queryVector)
+                  .withPrefilter(mask[0], maskLength)
                   .build();
         } else {
           query =
               new CagraQuery.Builder(getCuVSResourcesInstance())
                   .withTopK(topK)
                   .withSearchParams(searchParams)
-                  .withQueryVectors(CuVSMatrix.ofArray(new float[][] {target}))
+                  .withQueryVectors(queryVector)
                   .build();
         }
         searchResult = cagraIndex.search(query).getResults();
@@ -474,17 +477,18 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
         BruteForceIndex bruteforceIndex = cuvsIndex.getBruteforceIndex();
         assert bruteforceIndex != null;
         BruteForceQuery query = null;
+        float[][] queryVector = new float[][] {target};
         if (acceptDocs != null) {
           query =
               new BruteForceQuery.Builder(getCuVSResourcesInstance())
-                  .withQueryVectors(new float[][] {target})
-                  .withPrefilters(mask, mask[0].length())
+                  .withQueryVectors(queryVector)
+                  .withPrefilters(mask, maskLength)
                   .withTopK(topK)
                   .build();
         } else {
           query =
               new BruteForceQuery.Builder(getCuVSResourcesInstance())
-                  .withQueryVectors(new float[][] {target})
+                  .withQueryVectors(queryVector)
                   .withTopK(topK)
                   .build();
         }
@@ -493,7 +497,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
 
       // List expected to have only one entry because of single query "target".
       assert searchResult.size() == 1;
-
       final IntToIntFunction ordToDocFunction = (IntToIntFunction) rawValues::ordToDoc;
       final FloatToFloatFunction scoreCorrectionFunction =
           getScoreNormalizationFunc(fieldEntry.similarityFunction);

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -451,7 +451,13 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
         CagraIndex cagraIndex = cuvsIndex.getCagraIndex();
         assert cagraIndex != null;
         CagraQuery query = null;
-        CuVSMatrix queryVector = CuVSMatrix.ofArray(new float[][] {target});
+
+        CuVSMatrix.Builder<?> builder =
+            CuVSMatrix.deviceBuilder(
+                getCuVSResourcesInstance(), 1, target.length, CuVSMatrix.DataType.FLOAT);
+        builder.addVector(target);
+        CuVSMatrix queryVector = builder.build();
+
         if (acceptDocs != null) {
           query =
               new CagraQuery.Builder(getCuVSResourcesInstance())

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -20,10 +20,10 @@ import com.nvidia.cuvs.CagraQuery;
 import com.nvidia.cuvs.CagraSearchParams;
 import com.nvidia.cuvs.CuVSMatrix;
 import java.io.IOException;
+import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.codecs.CodecUtil;
@@ -46,7 +46,6 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.hnsw.IntToIntFunction;
 
@@ -57,14 +56,23 @@ import org.apache.lucene.util.hnsw.IntToIntFunction;
  */
 public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
 
-  @SuppressWarnings("unused")
-  private static final Logger log = Logger.getLogger(CuVS2510GPUVectorsReader.class.getName());
+  private static final LuceneProvider LUCENE_PROVIDER;
+  private static final List<VectorSimilarityFunction> VECTOR_SIMILARITY_FUNCTIONS;
 
-  private final FlatVectorsReader flatVectorsReader; // for reading the raw vectors
+  private final FlatVectorsReader flatVectorsReader;
   private final FieldInfos fieldInfos;
   private final IntObjectHashMap<FieldEntry> fields;
   private final IntObjectHashMap<GPUIndex> cuvsIndices;
   private final IndexInput cuvsIndexInput;
+
+  static {
+    try {
+      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      VECTOR_SIMILARITY_FUNCTIONS = LUCENE_PROVIDER.getSimilarityFunctions();
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e.getMessage());
+    }
+  }
 
   /**
    * Initializes the {@link CuVS2510GPUVectorsReader}, checks and loads the index.
@@ -79,7 +87,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
     this.flatVectorsReader = flatReader;
     this.fieldInfos = state.fieldInfos;
     this.fields = new IntObjectHashMap<>();
-
     String metaFileName =
         IndexFileNames.segmentFileName(
             state.segmentInfo.name, state.segmentSuffix, CUVS_META_CODEC_EXT);
@@ -104,7 +111,23 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
       }
       var ioContext = state.context.withReadAdvice(ReadAdvice.SEQUENTIAL);
       cuvsIndexInput = openCuVSInput(state, versionMeta, ioContext);
-      cuvsIndices = loadCuVSIndices();
+
+      // Detect if an instance of this reader is getting opened when there is a merge call.
+      boolean isMergeCall = false;
+      for (StackTraceElement s : Thread.currentThread().getStackTrace()) {
+        if ("getReaderForMerge".equals(s.getMethodName())) {
+          isMergeCall = true;
+          break;
+        }
+      }
+      // Do not load indexes on the GPU as they are not being used when merge happens.
+      // We reduce approximately 50% of device memory usage during merges with this approach.
+      if (!isMergeCall) {
+        cuvsIndices = loadCuVSIndices();
+      } else {
+        cuvsIndices = null;
+      }
+
       success = true;
     } finally {
       if (success == false) {
@@ -185,17 +208,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
     }
   }
 
-  // List of vector similarity functions. This list is defined here, in order
-  // to avoid an undesirable dependency on the declaration and order of values
-  // in VectorSimilarityFunction. The list values and order must be identical
-  // to that of {@link o.a.l.c.l.Lucene94FieldInfosFormat#SIMILARITY_FUNCTIONS}.
-  static final List<VectorSimilarityFunction> SIMILARITY_FUNCTIONS =
-      List.of(
-          VectorSimilarityFunction.EUCLIDEAN,
-          VectorSimilarityFunction.DOT_PRODUCT,
-          VectorSimilarityFunction.COSINE,
-          VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT);
-
   /**
    * Checks the distance function validity and returns it.
    *
@@ -205,14 +217,14 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    */
   static VectorSimilarityFunction readSimilarityFunction(DataInput input) throws IOException {
     int i = input.readInt();
-    if (i < 0 || i >= SIMILARITY_FUNCTIONS.size()) {
+    if (i < 0 || i >= VECTOR_SIMILARITY_FUNCTIONS.size()) {
       throw new IllegalArgumentException("invalid distance function: " + i);
     }
-    return SIMILARITY_FUNCTIONS.get(i);
+    return VECTOR_SIMILARITY_FUNCTIONS.get(i);
   }
 
   /**
-   * Reads the vector encoding (The numeric datatype of the vector values) from the DataInput.
+   * Reads the vector encoding (The numeric data type of the vector values) from the DataInput.
    *
    * @param input instance of DataInput
    * @return the vector encoding
@@ -282,9 +294,9 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    */
   private IntObjectHashMap<GPUIndex> loadCuVSIndices() throws IOException {
     var indices = new IntObjectHashMap<GPUIndex>();
-    for (var e : fields) {
-      var fieldEntry = e.value;
-      int fieldNumber = e.key;
+    for (var field : fields) {
+      var fieldEntry = field.value;
+      int fieldNumber = field.key;
       var cuvsIndex = loadCuVSIndex(fieldEntry);
       indices.put(fieldNumber, cuvsIndex);
     }
@@ -292,7 +304,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   }
 
   /**
-   * Loads the CAGRA and bruteforce index (if exists) onto the GPU.
+   * Loads the CAGRA and brute force index (if exists) onto the GPU.
    *
    * @param fieldEntry instance of {@link FieldEntry}
    * @return return the instance of {@link GPUIndex}
@@ -301,7 +313,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   private GPUIndex loadCuVSIndex(FieldEntry fieldEntry) throws IOException {
     CagraIndex cagraIndex = null;
     BruteForceIndex bruteForceIndex = null;
-
     try {
       long len = fieldEntry.cagraIndexLength();
       if (len > 0) {
@@ -311,7 +322,6 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
           cagraIndex = CagraIndex.newBuilder(getCuVSResourcesInstance()).from(in).build();
         }
       }
-
       len = fieldEntry.bruteForceIndexLength();
       if (len > 0) {
         long off = fieldEntry.bruteForceIndexOffset();
@@ -331,11 +341,12 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    */
   @Override
   public void close() throws IOException {
-    var closeableStream =
-        Stream.concat(
-            Stream.of(flatVectorsReader, cuvsIndexInput),
-            stream(cuvsIndices.values().iterator()).map(cursor -> cursor.value));
+    var closeableStream = Stream.of(flatVectorsReader, cuvsIndexInput);
     IOUtils.close(closeableStream::iterator);
+    if (cuvsIndices != null) {
+      var indexClosableStream = stream(cuvsIndices.values().iterator()).map(cursor -> cursor.value);
+      IOUtils.close(indexClosableStream::iterator);
+    }
     closeCuVSResourcesInstance();
   }
 
@@ -366,7 +377,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    */
   @Override
   public ByteVectorValues getByteVectorValues(String field) {
-    throw new UnsupportedOperationException("byte vectors not supported");
+    throw new UnsupportedOperationException("byte vectors are not currently supported");
   }
 
   /** Native float to float function */
@@ -375,126 +386,131 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   }
 
   /**
-   * Returns a long array from bits.
-   */
-  static long[] bitsToLongArray(Bits bits) {
-    if (bits instanceof FixedBitSet fixedBitSet) {
-      return fixedBitSet.getBits();
-    } else {
-      return FixedBitSet.copyOf(bits).getBits();
-    }
-  }
-
-  /**
    * Get the score normalization function.
    *
    * @param sim instance of VectorSimilarityFunction
    * @return an instance of the FloatToFloatFunction
    */
-  static FloatToFloatFunction getScoreNormalizationFunc(VectorSimilarityFunction sim) {
+  private static FloatToFloatFunction getScoreNormalizationFunc(VectorSimilarityFunction sim) {
     // TODO: check for different similarities
     return score -> (1f / (1f + score));
   }
 
-  // This is a hack - https://github.com/rapidsai/cuvs/issues/696
-  static final int FILTER_OVER_SAMPLE = 10;
-
   /**
-   * Returns the k nearest neighbor documents using cuVS's CAGRA or Bruteforce algorithm for this field, to the given vector.
+   * Returns the k nearest neighbor documents using cuVS's CAGRA or brute force algorithm for this field, to the given vector.
    */
   @Override
   public void search(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs)
       throws IOException {
-    var fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
+    FieldEntry fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
     if (fieldEntry.count() == 0 || knnCollector.k() == 0) {
       return;
     }
 
     var fieldNumber = fieldInfos.fieldInfo(field).number;
-
     GPUIndex cuvsIndex = cuvsIndices.get(fieldNumber);
     if (cuvsIndex == null) {
-      throw new IllegalStateException("not index found for field:" + field);
+      throw new IllegalStateException("Index not found for field:" + field);
     }
 
-    int collectorTopK = knnCollector.k();
+    final FloatVectorValues rawValues = flatVectorsReader.getFloatVectorValues(field);
+    final Bits acceptedOrds = rawValues.getAcceptOrds(acceptDocs);
+    BitSet[] mask = null;
+    int topK = knnCollector.k();
+
     if (acceptDocs != null) {
-      collectorTopK = knnCollector.k() * FILTER_OVER_SAMPLE;
+      mask = new BitSet[1]; // As there is only one query "target"
+      mask[0] = new BitSet(acceptedOrds.length());
+      for (int i = 0; i < acceptedOrds.length(); i++) {
+        if (acceptedOrds.get(i)) {
+          mask[0].set(i);
+        }
+      }
+      topK = Math.min(knnCollector.k() + 5, mask[0].cardinality());
     }
-    final int topK = Math.min(collectorTopK, fieldEntry.count());
-    assert topK > 0 : "Expected topK > 0, got:" + topK;
 
-    Map<Integer, Float> result;
-    if (knnCollector.k() <= 1024 && cuvsIndex.getCagraIndex() != null) {
-
-      CagraSearchParams searchParams;
-      if (knnCollector instanceof GPUPerLeafCuVSKnnCollector) {
-        GPUPerLeafCuVSKnnCollector collector = (GPUPerLeafCuVSKnnCollector) knnCollector;
-        searchParams =
-            new CagraSearchParams.Builder()
-                .withItopkSize(Math.max(collector.getiTopK(), topK))
-                .withSearchWidth(collector.getSearchWidth())
-                .build();
-      } else {
-        // Setting itopK as topK because in any case iTopK should be ATLEAST equal to topK
-        searchParams = new CagraSearchParams.Builder().withItopkSize(topK).build();
-      }
-
-      var query =
-          new CagraQuery.Builder(getCuVSResourcesInstance())
-              .withTopK(topK)
-              .withSearchParams(searchParams)
-              .withQueryVectors(CuVSMatrix.ofArray(new float[][] {target}))
-              .build();
-
-      CagraIndex cagraIndex = cuvsIndex.getCagraIndex();
+    try {
+      Map<Integer, Float> result;
       List<Map<Integer, Float>> searchResult = null;
-      try {
+      if (knnCollector.k() <= 1024 && cuvsIndex.getCagraIndex() != null) {
+        CagraSearchParams searchParams;
+        if (knnCollector instanceof GPUPerLeafCuVSKnnCollector) {
+          GPUPerLeafCuVSKnnCollector collector = (GPUPerLeafCuVSKnnCollector) knnCollector;
+          searchParams =
+              new CagraSearchParams.Builder()
+                  .withItopkSize(Math.max(collector.getiTopK(), topK))
+                  .withSearchWidth(collector.getSearchWidth())
+                  .build();
+        } else {
+          // Setting itopK as topK because in any case iTopK should be ATLEAST equal to topK
+          searchParams = new CagraSearchParams.Builder().withItopkSize(topK).build();
+        }
+        CagraIndex cagraIndex = cuvsIndex.getCagraIndex();
+        assert cagraIndex != null;
+        CagraQuery query = null;
+        if (acceptDocs != null) {
+          query =
+              new CagraQuery.Builder(getCuVSResourcesInstance())
+                  .withTopK(topK)
+                  .withSearchParams(searchParams)
+                  .withQueryVectors(CuVSMatrix.ofArray(new float[][] {target}))
+                  .withPrefilter(mask[0], mask[0].length())
+                  .build();
+        } else {
+          query =
+              new CagraQuery.Builder(getCuVSResourcesInstance())
+                  .withTopK(topK)
+                  .withSearchParams(searchParams)
+                  .withQueryVectors(CuVSMatrix.ofArray(new float[][] {target}))
+                  .build();
+        }
         searchResult = cagraIndex.search(query).getResults();
-      } catch (Throwable t) {
-        Utils.handleThrowable(t);
+      } else {
+        BruteForceIndex bruteforceIndex = cuvsIndex.getBruteforceIndex();
+        assert bruteforceIndex != null;
+        BruteForceQuery query = null;
+        if (acceptDocs != null) {
+          query =
+              new BruteForceQuery.Builder(getCuVSResourcesInstance())
+                  .withQueryVectors(new float[][] {target})
+                  .withPrefilters(mask, mask[0].length())
+                  .withTopK(topK)
+                  .build();
+        } else {
+          query =
+              new BruteForceQuery.Builder(getCuVSResourcesInstance())
+                  .withQueryVectors(new float[][] {target})
+                  .withTopK(topK)
+                  .build();
+        }
+        searchResult = bruteforceIndex.search(query).getResults();
       }
+
       // List expected to have only one entry because of single query "target".
       assert searchResult.size() == 1;
       result = searchResult.getFirst();
-    } else {
-      BruteForceIndex bruteforceIndex = cuvsIndex.getBruteforceIndex();
-      assert bruteforceIndex != null;
-      var queryBuilder =
-          new BruteForceQuery.Builder(getCuVSResourcesInstance())
-              .withQueryVectors(new float[][] {target})
-              .withTopK(topK);
-      BruteForceQuery query = queryBuilder.build();
 
-      List<Map<Integer, Float>> searchResult = null;
-      try {
-        searchResult = bruteforceIndex.search(query).getResults();
-      } catch (Throwable t) {
-        Utils.handleThrowable(t);
-      }
-      assert searchResult.size() == 1;
-      result = searchResult.getFirst();
-    }
-    assert result != null;
+      final IntToIntFunction ordToDocFunction = (IntToIntFunction) rawValues::ordToDoc;
+      final FloatToFloatFunction scoreCorrectionFunction =
+          getScoreNormalizationFunc(fieldEntry.similarityFunction);
 
-    final var rawValues = flatVectorsReader.getFloatVectorValues(field);
-    final Bits acceptedOrds = rawValues.getAcceptOrds(acceptDocs);
-    final var ordToDocFunction = (IntToIntFunction) rawValues::ordToDoc;
-    final var scoreCorrectionFunction = getScoreNormalizationFunc(fieldEntry.similarityFunction);
-
-    for (var entry : result.entrySet()) {
-      int ord = entry.getKey();
-      float score = entry.getValue();
-      if (acceptedOrds == null || acceptedOrds.get(ord)) {
+      for (var entry : result.entrySet()) {
+        int ord = entry.getKey();
+        float score = entry.getValue();
         if (knnCollector.earlyTerminated()) {
           break;
         }
+        if (ord < 0) {
+          continue;
+        }
         assert ord >= 0 : "unexpected ord: " + ord;
-        int doc = ordToDocFunction.apply(ord);
         float correctedScore = scoreCorrectionFunction.apply(score);
+        int doc = ordToDocFunction.apply(ord);
         knnCollector.incVisitedCount(1);
         knnCollector.collect(doc, correctedScore);
       }
+    } catch (Throwable t) {
+      Utils.handleThrowable(t);
     }
   }
 
@@ -506,7 +522,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   @Override
   public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs)
       throws IOException {
-    throw new UnsupportedOperationException("byte vectors not supported");
+    throw new UnsupportedOperationException("Byte vectors are not currently supported");
   }
 
   /**
@@ -526,7 +542,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
      * Returns an instance of FieldEntry.
      *
      * @param input instance of IndexInput
-     * @param vectorEncoding The numeric datatype of the vector values
+     * @param vectorEncoding The numeric data type of the vector values
      * @param similarityFunction Vector similarity function; used in search to return top K most similar vectors to a target vector
      * @return an instance of FieldEntry
      * @throws IOException I/O Exceptions
@@ -562,7 +578,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    * @param in
    * @throws CorruptIndexException
    */
-  static void checkVersion(int versionMeta, int versionVectorData, IndexInput in)
+  private static void checkVersion(int versionMeta, int versionVectorData, IndexInput in)
       throws CorruptIndexException {
     if (versionMeta != versionVectorData) {
       throw new CorruptIndexException(
@@ -588,7 +604,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   /**
    * Gets the map of {@link GPUIndex} objects.
    *
-   * @return the map of gpu index objects
+   * @return the map of GPU index objects
    */
   public IntObjectHashMap<GPUIndex> getCuvsIndexes() {
     return cuvsIndices;

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -44,6 +44,7 @@ import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IOContext.Context;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.Bits;
@@ -112,20 +113,15 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
       }
       var ioContext = state.context.withReadAdvice(ReadAdvice.SEQUENTIAL);
       cuvsIndexInput = openCuVSInput(state, versionMeta, ioContext);
-      // Detect if an instance of this reader is getting opened when there is a merge call.
-      boolean isMergeCall = false;
-      for (StackTraceElement s : Thread.currentThread().getStackTrace()) {
-        if ("getReaderForMerge".equals(s.getMethodName())) {
-          isMergeCall = true;
-          break;
-        }
-      }
-      // Do not load indexes on the GPU as they are not being used when merge happens.
-      // We reduce approximately 50% of device memory usage during merges with this approach.
-      if (!isMergeCall) {
-        cuvsIndices = loadCuVSIndices();
-      } else {
+      /*
+       * Only load indexes on the GPU when this reader is opening for searches.
+       * Do not load indexes on the GPU when this reader is opening during merge calls.
+       * With this approach we reduce device memory usage by approximately 50% during merges.
+       */
+      if (state.context.context().equals(Context.MERGE)) {
         cuvsIndices = null;
+      } else {
+        cuvsIndices = loadCuVSIndices();
       }
       success = true;
     } finally {

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -11,6 +11,7 @@ import static com.nvidia.cuvs.lucene.CuVS2510GPUVectorsFormat.CUVS_META_CODEC_NA
 import static com.nvidia.cuvs.lucene.CuVS2510GPUVectorsFormat.VERSION_CURRENT;
 import static com.nvidia.cuvs.lucene.ThreadLocalCuVSResourcesProvider.closeCuVSResourcesInstance;
 import static com.nvidia.cuvs.lucene.ThreadLocalCuVSResourcesProvider.getCuVSResourcesInstance;
+import static com.nvidia.cuvs.lucene.Utils.info;
 import static org.apache.lucene.index.VectorEncoding.FLOAT32;
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
@@ -27,8 +28,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Logger;
-import java.util.stream.IntStream;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnFieldVectorsWriter;
 import org.apache.lucene.codecs.KnnVectorsReader;
@@ -60,27 +59,15 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
 
   private static final long SHALLOW_RAM_BYTES_USED =
       shallowSizeOfInstance(CuVS2510GPUVectorsWriter.class);
-
-  @SuppressWarnings("unused")
-  private static final Logger log = Logger.getLogger(CuVS2510GPUVectorsWriter.class.getName());
-
-  /** The name of the CUVS component for the info-stream * */
   private static final String CUVS_COMPONENT = "CUVS";
-
   private static final LuceneProvider LUCENE_PROVIDER;
   private static final List<VectorSimilarityFunction> VECTOR_SIMILARITY_FUNCTIONS;
-
-  // The minimum number of vectors in the dataset required before
-  // we attempt to build a Cagra index
-  static final int MIN_CAGRA_INDEX_SIZE = 2;
-
+  private static final int MIN_CAGRA_INDEX_SIZE = 2;
   private final GPUSearchParams gpuSearchParams;
-
   private final FlatVectorsWriter flatVectorsWriter;
   private final List<GPUFieldWriter> fields = new ArrayList<>();
   private IndexOutput meta = null, cuvsIndex = null;
   private final InfoStream infoStream;
-  private boolean finished;
 
   static {
     try {
@@ -96,13 +83,13 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    */
   public enum IndexType {
 
-    /** Builds a Cagra index. */
+    /** Builds a CAGRA index. */
     CAGRA(true, false),
 
     /** Builds a Brute Force index. */
     BRUTE_FORCE(false, true),
 
-    /** Builds a Cagra and a Brute Force index. */
+    /** Builds both - CAGRA and Brute Force indexes. */
     CAGRA_AND_BRUTE_FORCE(true, true);
     private final boolean cagra, bruteForce;
 
@@ -111,21 +98,11 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
       this.bruteForce = bruteForce;
     }
 
-    /**
-     * Check if cagra is set
-     *
-     * @return is cagra set
-     */
-    public boolean cagra() {
+    public boolean isCagra() {
       return cagra;
     }
 
-    /**
-     * Check if bruteforce is set
-     *
-     * @return is bruteforce set
-     */
-    public boolean bruteForce() {
+    public boolean isBruteForce() {
       return bruteForce;
     }
   }
@@ -155,7 +132,6 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
 
     boolean success = false;
     try {
-
       meta = state.directory.createOutput(metaFileName, state.context);
       cuvsIndex = state.directory.createOutput(cagraFileName, state.context);
       CodecUtil.writeIndexHeader(
@@ -170,7 +146,6 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
           VERSION_CURRENT,
           state.segmentInfo.getId(),
           state.segmentSuffix);
-
       success = true;
     } finally {
       if (success == false) {
@@ -197,98 +172,43 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
   }
 
   /**
-   * Returns a string containing meta information like graph degree etc.
-   *
-   * @param size index size
-   * @param args other parameters like graph degree, Intermediate graph degree, etc.
-   * @return the string containing the meta information
-   */
-  static String indexMsg(int size, int... args) {
-    StringBuilder sb = new StringBuilder("cagra index params");
-    sb.append(": size=").append(size);
-    sb.append(", intGraphDegree=").append(args[0]);
-    sb.append(", actualIntGraphDegree=").append(args[1]);
-    sb.append(", graphDegree=").append(args[2]);
-    sb.append(", actualGraphDegree=").append(args[3]);
-    return sb.toString();
-  }
-
-  /**
-   * Builds and returns an instance of CagraIndexParams.
-   *
-   * @param size the size of the index
-   * @return an instance of CagraIndexParams
-   */
-  private CagraIndexParams cagraIndexParams(int size) {
-    if (size < 2) {
-      // https://github.com/rapidsai/cuvs/issues/666
-      throw new IllegalArgumentException("cagra index must be greater than 2");
-    }
-
-    return new CagraIndexParams.Builder()
-        .withNumWriterThreads(gpuSearchParams.getWriterThreads())
-        .withIntermediateGraphDegree(gpuSearchParams.getIntermediateGraphDegree())
-        .withGraphDegree(gpuSearchParams.getGraphdegree())
-        .withCagraGraphBuildAlgo(gpuSearchParams.getCagraGraphBuildAlgo())
-        .build();
-  }
-
-  /**
-   * Utility to print info/debug messages via InfoStream.
-   *
-   * @param msg
-   */
-  private void info(String msg) {
-    if (infoStream.isEnabled(CUVS_COMPONENT)) {
-      infoStream.message(CUVS_COMPONENT, msg);
-    }
-  }
-
-  /**
-   * Creates CAGRA and/or Bruteforce indexes and writes them.
+   * Creates CAGRA and/or brute force indexes and writes them.
    *
    * @param fieldInfo Instance of the FieldInFo to use
    * @param vectors list of float vectors to index
    * @throws IOException
    */
   private void writeFieldInternal(FieldInfo fieldInfo, List<float[]> vectors) throws IOException {
-    if (vectors.size() == 0) {
+    if (vectors != null && vectors.size() == 0) {
       writeEmpty(fieldInfo);
       return;
     }
     long cagraIndexOffset, cagraIndexLength = 0L;
     long bruteForceIndexOffset, bruteForceIndexLength = 0L;
 
-    // workaround for the minimum number of vectors for Cagra
+    /*
+     * CAGRA has an issue when asked to build an index with just one vector.
+     * Hence, we currently switch to brute force in such a case.
+     */
     IndexType indexType =
-        gpuSearchParams.getIndexType().cagra() && vectors.size() < MIN_CAGRA_INDEX_SIZE
+        gpuSearchParams.getIndexType().isCagra() && vectors.size() < MIN_CAGRA_INDEX_SIZE
             ? IndexType.BRUTE_FORCE
             : gpuSearchParams.getIndexType();
 
     try {
+      CuVSMatrix dataset =
+          Utils.createFloatMatrix(
+              vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
 
       cagraIndexOffset = cuvsIndex.getFilePointer();
-      if (indexType.cagra()) {
-        try {
-          var cagraIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
-          CuVSMatrix dataset =
-              Utils.createFloatMatrix(
-                  vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
-          writeCagraIndex(cagraIndexOutputStream, dataset);
-        } catch (Throwable t) {
-          Utils.handleThrowableWithIgnore(t, CANNOT_GENERATE_CAGRA);
-          // workaround for cuVS issue
-          indexType = IndexType.BRUTE_FORCE;
-        }
+      if (indexType.isCagra()) {
+        var cagraIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
+        writeCagraIndex(cagraIndexOutputStream, dataset);
         cagraIndexLength = cuvsIndex.getFilePointer() - cagraIndexOffset;
       }
-
       bruteForceIndexOffset = cuvsIndex.getFilePointer();
-      if (indexType.bruteForce()) {
+      if (indexType.isBruteForce()) {
         var bruteForceIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
-        CuVSMatrix dataset =
-            Utils.createFloatMatrix(
-                vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
         writeBruteForceIndex(bruteForceIndexOutputStream, dataset);
         bruteForceIndexLength = cuvsIndex.getFilePointer() - bruteForceIndexOffset;
       }
@@ -313,18 +233,19 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    * @throws Throwable
    */
   private void writeCagraIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
-    if (dataset.size() < 2) {
-      throw new IllegalArgumentException(dataset.size() + " vectors, less than min [2] required");
-    }
-    CagraIndexParams params = cagraIndexParams((int) dataset.size());
-    long startTime = System.nanoTime();
+    CagraIndexParams params =
+        new CagraIndexParams.Builder()
+            .withNumWriterThreads(gpuSearchParams.getWriterThreads())
+            .withIntermediateGraphDegree(gpuSearchParams.getIntermediateGraphDegree())
+            .withGraphDegree(gpuSearchParams.getGraphdegree())
+            .withCagraGraphBuildAlgo(gpuSearchParams.getCagraGraphBuildAlgo())
+            .withCuVSIvfPqParams(gpuSearchParams.getCuVSIvfPqParams())
+            .build();
     CagraIndex index =
         CagraIndex.newBuilder(getCuVSResourcesInstance())
             .withDataset(dataset)
             .withIndexParams(params)
             .build();
-    long elapsedMillis = Utils.nanosToMillis(System.nanoTime() - startTime);
-    info("Cagra index created in " + elapsedMillis + "ms, with " + dataset.size() + " vectors");
     Path tmpFile =
         Files.createTempFile(getCuVSResourcesInstance().tempDirectory(), "tmpindex", "cag");
     index.serialize(os, tmpFile);
@@ -332,31 +253,28 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
   }
 
   /**
-   * Builds and writes the Bruteforce index.
+   * Builds and writes the brute force index.
    *
-   * @param os Instance of OutputStream to write the index to
-   * @param dataset Instance of CuVSMatrix that holds the dataset
+   * @param os Instance of OutputStream to write the index bytes to
+   * @param dataset Instance of CuVSMatrix that holds the data set
    * @throws Throwable
    */
   private void writeBruteForceIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
     BruteForceIndexParams params =
         new BruteForceIndexParams.Builder()
-            .withNumWriterThreads(32) // TODO: Make this configurable.
+            .withNumWriterThreads(gpuSearchParams.getWriterThreads())
             .build();
-    long startTime = System.nanoTime();
     var index =
         BruteForceIndex.newBuilder(getCuVSResourcesInstance())
             .withIndexParams(params)
             .withDataset(dataset)
             .build();
-    long elapsedMillis = Utils.nanosToMillis(System.nanoTime() - startTime);
-    info("bf index created in " + elapsedMillis + "ms, with " + dataset.size() + " vectors");
     index.serialize(os);
     index.close();
   }
 
   /**
-   * Creates the CAGRA and/or Bruteforce indexes and writes them to the disk.
+   * Creates the CAGRA and/or brute force indexes and writes them to the disk.
    */
   @Override
   public void flush(int maxDoc, DocMap sortMap) throws IOException {
@@ -389,16 +307,13 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    */
   private void writeSortingField(GPUFieldWriter fieldData, Sorter.DocMap sortMap)
       throws IOException {
-
     DocsWithFieldSet oldDocsWithFieldSet = fieldData.getDocsWithFieldSet();
-    final int[] new2OldOrd = new int[oldDocsWithFieldSet.cardinality()]; // new ord to old ord
+    final int[] new2OldOrd = new int[oldDocsWithFieldSet.cardinality()];
     mapOldOrdToNewOrd(oldDocsWithFieldSet, sortMap, null, new2OldOrd, null);
-
     List<float[]> sortedVectors = new ArrayList<float[]>();
     for (int i = 0; i < fieldData.getVectors().size(); i++) {
       sortedVectors.add(fieldData.getVectors().get(new2OldOrd[i]));
     }
-
     writeFieldInternal(fieldData.fieldInfo(), sortedVectors);
   }
 
@@ -419,8 +334,8 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    * @param count number of vectors
    * @param cagraIndexOffset CAGRA index offset
    * @param cagraIndexLength CAGRA index length
-   * @param bruteForceIndexOffset Bruteforce index offset
-   * @param bruteForceIndexLength Bruteforce index length
+   * @param bruteForceIndexOffset Brute force index offset
+   * @param bruteForceIndexLength Brute force index length
    * @throws IOException I/O Exceptions
    */
   private void writeMeta(
@@ -448,36 +363,27 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
         return (byte) i;
       }
     }
-    throw new IllegalArgumentException("invalid distance function: " + func);
+    throw new IllegalArgumentException("Invalid distance function: " + func);
   }
-
-  // We currently ignore this, until cuVS supports tiered indices
-  private static final String CANNOT_GENERATE_CAGRA =
-      """
-      Could not generate an intermediate CAGRA graph because the initial \
-      kNN graph contains too many invalid or duplicated neighbor nodes. \
-      This error can occur, for example, if too many overflows occur \
-      during the norm computation between the dataset vectors\
-      """;
 
   /**
    * Uses the cuVS API to merge CAGRA indexes.
+   *
+   * This is currently (and intentionally) marked as unused and will be plugged in later.
    *
    * @param fieldInfo instance of the FieldInfo
    * @param mergeState instance of the MergeState
    * @throws IOException I/O Exceptions
    */
+  @SuppressWarnings("unused")
   private void mergeCagraIndexes(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
     try {
-
       List<CagraIndex> cagraIndexes = new ArrayList<>();
       // We need this count so that the merged segment's meta information has the vector count.
       int totalVectorCount = 0;
-
       for (int i = 0; i < mergeState.knnVectorsReaders.length; i++) {
         KnnVectorsReader knnReader = mergeState.knnVectorsReaders[i];
         // Access the CAGRA index for this field from the reader
-
         if (knnReader != null) {
           if (knnReader instanceof CuVS2510GPUVectorsReader cvr) {
             if (cvr != null) {
@@ -495,12 +401,56 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
         }
       }
       assert cagraIndexes.size() > 1;
-
       CagraIndex mergedIndex =
           CagraIndex.merge(cagraIndexes.toArray(new CagraIndex[cagraIndexes.size()]));
       writeMergedCagraIndex(fieldInfo, mergedIndex, totalVectorCount);
-      info("Successfully merged " + cagraIndexes.size() + " CAGRA indexes using native merge API");
+      info(
+          infoStream,
+          CUVS_COMPONENT,
+          "Successfully merged " + cagraIndexes.size() + " CAGRA indexes using native merge API");
+    } catch (Throwable t) {
+      Utils.handleThrowable(t);
+    }
+  }
 
+  /**
+   * Extracts the CAGRA index for a specific field from a CuVSVectorsReader.
+   */
+  private CagraIndex getCagraIndexFromReader(CuVS2510GPUVectorsReader reader, String fieldName) {
+    try {
+      IntObjectHashMap<GPUIndex> cuvsIndices = reader.getCuvsIndexes();
+      FieldInfos fieldInfos = reader.getFieldInfos();
+      FieldInfo fieldInfo = fieldInfos.fieldInfo(fieldName);
+      if (fieldInfo != null) {
+        GPUIndex cuvsIndex = cuvsIndices.get(fieldInfo.number);
+        if (cuvsIndex != null) {
+          return cuvsIndex.getCagraIndex();
+        }
+      }
+    } catch (Exception e) {
+      info(
+          infoStream,
+          CUVS_COMPONENT,
+          "Failed to extract CAGRA index for field " + fieldName + ": " + e.getMessage());
+      throw e;
+    }
+    return null;
+  }
+
+  /**
+   * Writes a pre-built merged CAGRA index to the output.
+   */
+  private void writeMergedCagraIndex(FieldInfo fieldInfo, CagraIndex mergedIndex, int vectorCount)
+      throws IOException {
+    try {
+      long cagraIndexOffset = cuvsIndex.getFilePointer();
+      var cagraIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
+      Path tmpFile =
+          Files.createTempFile(getCuVSResourcesInstance().tempDirectory(), "mergedindex", "cag");
+      mergedIndex.serialize(cagraIndexOutputStream, tmpFile);
+      long cagraIndexLength = cuvsIndex.getFilePointer() - cagraIndexOffset;
+      writeMeta(fieldInfo, vectorCount, cagraIndexOffset, cagraIndexLength, 0L, 0L);
+      mergedIndex.close();
     } catch (Throwable t) {
       Utils.handleThrowable(t);
     }
@@ -527,9 +477,6 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    * when non-CAGRA index types are used (for e.g. Brute Force index).
    */
   private void vectorBasedMerge(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
-    if (fieldInfo.getVectorEncoding() != FLOAT32) {
-      throw new AssertionError("Only Float32 supported");
-    }
     try {
       List<float[]> dataset =
           createListFromMergedVectors(
@@ -541,83 +488,24 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
   }
 
   /**
-   * Extracts the CAGRA index for a specific field from a CuVSVectorsReader.
-   */
-  private CagraIndex getCagraIndexFromReader(CuVS2510GPUVectorsReader reader, String fieldName) {
-    try {
-      IntObjectHashMap<GPUIndex> cuvsIndices = reader.getCuvsIndexes();
-      FieldInfos fieldInfos = reader.getFieldInfos();
-
-      FieldInfo fieldInfo = fieldInfos.fieldInfo(fieldName);
-
-      if (fieldInfo != null) {
-        GPUIndex cuvsIndex = cuvsIndices.get(fieldInfo.number);
-        if (cuvsIndex != null) {
-          return cuvsIndex.getCagraIndex();
-        }
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-      info("Failed to extract CAGRA index for field " + fieldName + ": " + e.getMessage());
-    }
-    return null;
-  }
-
-  /**
-   * Writes a pre-built merged CAGRA index to the output.
-   */
-  private void writeMergedCagraIndex(FieldInfo fieldInfo, CagraIndex mergedIndex, int vectorCount)
-      throws IOException {
-    try {
-      long cagraIndexOffset = cuvsIndex.getFilePointer();
-      var cagraIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
-
-      // Serialize the merged index
-      Path tmpFile =
-          Files.createTempFile(getCuVSResourcesInstance().tempDirectory(), "mergedindex", "cag");
-      mergedIndex.serialize(cagraIndexOutputStream, tmpFile);
-      long cagraIndexLength = cuvsIndex.getFilePointer() - cagraIndexOffset;
-
-      writeMeta(fieldInfo, vectorCount, cagraIndexOffset, cagraIndexLength, 0L, 0L);
-
-      // Clean up the merged index
-      mergedIndex.close();
-    } catch (Throwable t) {
-      Utils.handleThrowable(t);
-    }
-  }
-
-  /**
    * Write field for merging.
    */
   @Override
   public void mergeOneField(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
     flatVectorsWriter.mergeOneField(fieldInfo, mergeState);
+    vectorBasedMerge(fieldInfo, mergeState);
+  }
 
-    if (gpuSearchParams.getIndexType().cagra() && !gpuSearchParams.getIndexType().bruteForce()) {
-      // Since CAGRA merge does not support merging of indexes with purging of deletes,
-      // we fallback to vector-based re-indexing. Issue:
-      // https://github.com/rapidsai/cuvs/issues/1253
-      boolean hasDeletions =
-          IntStream.range(0, mergeState.liveDocs.length)
-              .anyMatch(
-                  i ->
-                      mergeState.liveDocs[i] == null
-                          || IntStream.range(0, mergeState.maxDocs[i])
-                              .anyMatch(j -> !mergeState.liveDocs[i].get(j)));
-
-      if (mergeState.knnVectorsReaders.length > 1 && !hasDeletions) {
-        mergeCagraIndexes(fieldInfo, mergeState);
-      } else {
-        // CAGRA's merge API does not handle the trivial case of merging 1 index.
-        vectorBasedMerge(fieldInfo, mergeState);
-      }
-
-    } else {
-      // If there is a Brute Force index then re-index using the vectors even if there is a CAGRA
-      // index.
-      vectorBasedMerge(fieldInfo, mergeState);
+  /**
+   * Returns the memory usage of this object in bytes.
+   */
+  @Override
+  public long ramBytesUsed() {
+    long total = SHALLOW_RAM_BYTES_USED;
+    for (var field : fields) {
+      total += field.ramBytesUsed();
     }
+    return total;
   }
 
   /**
@@ -625,12 +513,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    */
   @Override
   public void finish() throws IOException {
-    if (finished) {
-      throw new IllegalStateException("already finished");
-    }
-    finished = true;
     flatVectorsWriter.finish();
-
     if (meta != null) {
       // write end of fields marker
       meta.writeInt(-1);
@@ -648,17 +531,5 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
   public void close() throws IOException {
     IOUtils.close(meta, cuvsIndex, flatVectorsWriter);
     closeCuVSResourcesInstance();
-  }
-
-  /**
-   * Returns the memory usage of this object in bytes.
-   */
-  @Override
-  public long ramBytesUsed() {
-    long total = SHALLOW_RAM_BYTES_USED;
-    for (var field : fields) {
-      total += field.ramBytesUsed();
-    }
-    return total;
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -123,13 +123,11 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
     this.gpuSearchParams = gpuSearchParams;
     this.flatVectorsWriter = flatVectorsWriter;
     this.infoStream = state.infoStream;
-
     String metaFileName =
         IndexFileNames.segmentFileName(
             state.segmentInfo.name, state.segmentSuffix, CUVS_META_CODEC_EXT);
     String cagraFileName =
         IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, CUVS_INDEX_EXT);
-
     boolean success = false;
     try {
       meta = state.directory.createOutput(metaFileName, state.context);
@@ -161,7 +159,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
   public KnnFieldVectorsWriter<?> addField(FieldInfo fieldInfo) throws IOException {
     var encoding = fieldInfo.getVectorEncoding();
     if (encoding != FLOAT32) {
-      throw new IllegalArgumentException("expected float32, got:" + encoding);
+      throw new IllegalArgumentException("Expected float32, got:" + encoding);
     }
     var writer = Objects.requireNonNull(flatVectorsWriter.addField(fieldInfo));
     @SuppressWarnings("unchecked")
@@ -188,7 +186,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
 
     /*
      * CAGRA has an issue when asked to build an index with just one vector.
-     * Hence, we currently switch to brute force in such a case.
+     * Hence, we currently fallback to brute force in such a case.
      */
     IndexType indexType =
         gpuSearchParams.getIndexType().isCagra() && vectors.size() < MIN_CAGRA_INDEX_SIZE
@@ -196,23 +194,31 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
             : gpuSearchParams.getIndexType();
 
     try {
-      CuVSMatrix dataset =
-          Utils.createFloatMatrix(
-              vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
-
       cagraIndexOffset = cuvsIndex.getFilePointer();
       if (indexType.isCagra()) {
         var cagraIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
-        writeCagraIndex(cagraIndexOutputStream, dataset);
+        try {
+          CuVSMatrix dataset =
+              Utils.createFloatMatrix(
+                  vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
+          writeCagraIndex(cagraIndexOutputStream, dataset);
+        } catch (Throwable t) {
+          // Fallback to brute force in a few cases, for now.
+          Utils.handleThrowableWithIgnore(t, t.getMessage());
+          indexType = IndexType.BRUTE_FORCE;
+        }
         cagraIndexLength = cuvsIndex.getFilePointer() - cagraIndexOffset;
       }
       bruteForceIndexOffset = cuvsIndex.getFilePointer();
       if (indexType.isBruteForce()) {
         var bruteForceIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
-        writeBruteForceIndex(bruteForceIndexOutputStream, dataset);
+        CuVSMatrix dataset2 =
+            Utils.createFloatMatrix(
+                vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
+
+        writeBruteForceIndex(bruteForceIndexOutputStream, dataset2);
         bruteForceIndexLength = cuvsIndex.getFilePointer() - bruteForceIndexOffset;
       }
-
       writeMeta(
           fieldInfo,
           vectors.size(),

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -59,15 +59,16 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
 
   private static final long SHALLOW_RAM_BYTES_USED =
       shallowSizeOfInstance(CuVS2510GPUVectorsWriter.class);
-  private static final String CUVS_COMPONENT = "CUVS";
+  private static final String COMPONENT = "CuVS2510GPUVectorsWriter";
   private static final LuceneProvider LUCENE_PROVIDER;
   private static final List<VectorSimilarityFunction> VECTOR_SIMILARITY_FUNCTIONS;
   private static final int MIN_CAGRA_INDEX_SIZE = 2;
+
   private final GPUSearchParams gpuSearchParams;
   private final FlatVectorsWriter flatVectorsWriter;
   private final List<GPUFieldWriter> fields = new ArrayList<>();
-  private IndexOutput meta = null, cuvsIndex = null;
   private final InfoStream infoStream;
+  private IndexOutput meta = null, cuvsIndex = null;
 
   static {
     try {
@@ -198,10 +199,10 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
       if (indexType.isCagra()) {
         var cagraIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
         try {
-          CuVSMatrix dataset =
+          CuVSMatrix cagraDataset =
               Utils.createFloatMatrix(
                   vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
-          writeCagraIndex(cagraIndexOutputStream, dataset);
+          writeCagraIndex(cagraIndexOutputStream, cagraDataset);
         } catch (Throwable t) {
           // Fallback to brute force in a few cases, for now.
           Utils.handleThrowableWithIgnore(t, t.getMessage());
@@ -212,11 +213,11 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
       bruteForceIndexOffset = cuvsIndex.getFilePointer();
       if (indexType.isBruteForce()) {
         var bruteForceIndexOutputStream = new IndexOutputOutputStream(cuvsIndex);
-        CuVSMatrix dataset2 =
+        CuVSMatrix bruteforceDataset =
             Utils.createFloatMatrix(
                 vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
 
-        writeBruteForceIndex(bruteForceIndexOutputStream, dataset2);
+        writeBruteForceIndex(bruteForceIndexOutputStream, bruteforceDataset);
         bruteForceIndexLength = cuvsIndex.getFilePointer() - bruteForceIndexOffset;
       }
       writeMeta(
@@ -252,9 +253,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
             .withDataset(dataset)
             .withIndexParams(params)
             .build();
-    Path tmpFile =
-        Files.createTempFile(getCuVSResourcesInstance().tempDirectory(), "tmpindex", "cag");
-    index.serialize(os, tmpFile);
+    index.serialize(os);
     index.close();
   }
 
@@ -412,7 +411,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
       writeMergedCagraIndex(fieldInfo, mergedIndex, totalVectorCount);
       info(
           infoStream,
-          CUVS_COMPONENT,
+          COMPONENT,
           "Successfully merged " + cagraIndexes.size() + " CAGRA indexes using native merge API");
     } catch (Throwable t) {
       Utils.handleThrowable(t);
@@ -436,7 +435,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
     } catch (Exception e) {
       info(
           infoStream,
-          CUVS_COMPONENT,
+          COMPONENT,
           "Failed to extract CAGRA index for field " + fieldName + ": " + e.getMessage());
       throw e;
     }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -69,6 +69,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
   private final List<GPUFieldWriter> fields = new ArrayList<>();
   private final InfoStream infoStream;
   private IndexOutput meta = null, cuvsIndex = null;
+  private boolean finished;
 
   static {
     try {
@@ -518,6 +519,10 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    */
   @Override
   public void finish() throws IOException {
+    if (finished) {
+      throw new IllegalStateException("already finished");
+    }
+    finished = true;
     flatVectorsWriter.finish();
     if (meta != null) {
       // write end of fields marker

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUFieldWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUFieldWriter.java
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 package com.nvidia.cuvs.lucene;
@@ -53,6 +53,20 @@ import org.apache.lucene.util.RamUsageEstimator;
    */
   List<float[]> getVectors() {
     return flatFieldVectorsWriter.getVectors();
+  }
+
+  /**
+   * Gets the vector dimension.
+   *
+   * @return the vector dimension
+   */
+  int getVectorDimension() {
+    List<float[]> vectors = flatFieldVectorsWriter.getVectors();
+    if (vectors != null && vectors.size() > 0) {
+      return vectors.get(0).length;
+    } else {
+      return -1;
+    }
   }
 
   /**

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -17,12 +17,12 @@ public class GPUSearchParams {
    * TODO: Update boundaries for all parameters when a consensus is reached.
    * Issue: https://github.com/rapidsai/cuvs-lucene/issues/99
    */
-  private static final int MIN_WRITER_THREADS = 1;
-  private static final int MAX_WRITER_THREADS = 512;
-  private static final int MIN_INT_GRAPH_DEG = 2;
-  private static final int MAX_INT_GRAPH_DEG = 512;
-  private static final int MIN_GRAPH_DEG = 1;
-  private static final int MAX_GRAPH_DEG = 512;
+  public static final int MIN_WRITER_THREADS = 1;
+  public static final int MAX_WRITER_THREADS = 512;
+  public static final int MIN_INT_GRAPH_DEG = 2;
+  public static final int MAX_INT_GRAPH_DEG = 512;
+  public static final int MIN_GRAPH_DEG = 1;
+  public static final int MAX_GRAPH_DEG = 512;
 
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
   public static final int DEFAULT_GRAPH_DEGREE = 64;
@@ -260,9 +260,6 @@ public class GPUSearchParams {
       }
       if (Objects.isNull(indexType)) {
         throw new IllegalArgumentException("indexType cannot be null.");
-      }
-      if (Objects.isNull(cuVSIvfPqParams)) {
-        throw new IllegalArgumentException("cuVSIvfPqParams cannot be null.");
       }
     }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -9,6 +9,7 @@ import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
 import com.nvidia.cuvs.CuVSIvfPqParams;
 import com.nvidia.cuvs.lucene.CuVS2510GPUVectorsWriter.IndexType;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 public class GPUSearchParams {
 
@@ -23,13 +24,17 @@ public class GPUSearchParams {
   private static final int MIN_GRAPH_DEG = 1;
   private static final int MAX_GRAPH_DEG = 512;
 
-  public static final CuVSIvfPqParams DEFAULT_IVF_PQ_PARAMS = new CuVSIvfPqParams.Builder().build();
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
   public static final int DEFAULT_GRAPH_DEGREE = 64;
   public static final CagraGraphBuildAlgo DEFAULT_CAGRA_GRAPH_BUILD_ALGO =
       CagraGraphBuildAlgo.NN_DESCENT;
   public static final IndexType DEFAULT_INDEX_TYPE = IndexType.CAGRA;
   public static final int DEFAULT_WRITER_THREADS = 1;
+
+  public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
+      () -> {
+        return new CuVSIvfPqParams.Builder().build();
+      };
 
   private final int writerThreads;
   private final int intermediateGraphDegree;
@@ -143,7 +148,7 @@ public class GPUSearchParams {
     private int graphdegree = DEFAULT_GRAPH_DEGREE;
     private CagraGraphBuildAlgo cagraGraphBuildAlgo = DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
     private IndexType indexType = DEFAULT_INDEX_TYPE;
-    private CuVSIvfPqParams cuVSIvfPqParams = DEFAULT_IVF_PQ_PARAMS;
+    private CuVSIvfPqParams cuVSIvfPqParams = null;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -267,6 +272,9 @@ public class GPUSearchParams {
      * @return instance of {@link GPUSearchParams}
      */
     public GPUSearchParams build() {
+      if (Objects.isNull(cuVSIvfPqParams)) {
+        cuVSIvfPqParams = DEFAULT_IVF_PQ_PARAMS.get();
+      }
       validate();
       return new GPUSearchParams(
           writerThreads,

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -6,6 +6,7 @@
 package com.nvidia.cuvs.lucene;
 
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
+import com.nvidia.cuvs.CuVSIvfPqParams;
 import com.nvidia.cuvs.lucene.CuVS2510GPUVectorsWriter.IndexType;
 import java.util.Objects;
 
@@ -16,17 +17,26 @@ public class GPUSearchParams {
    * Issue: https://github.com/rapidsai/cuvs-lucene/issues/99
    */
   private static final int MIN_WRITER_THREADS = 1;
-  private static final int MAX_WRITER_THREADS = 32;
+  private static final int MAX_WRITER_THREADS = 512;
   private static final int MIN_INT_GRAPH_DEG = 2;
-  private static final int MAX_INT_GRAPH_DEG = 128;
+  private static final int MAX_INT_GRAPH_DEG = 512;
   private static final int MIN_GRAPH_DEG = 1;
-  private static final int MAX_GRAPH_DEG = 64;
+  private static final int MAX_GRAPH_DEG = 512;
+
+  public static final CuVSIvfPqParams DEFAULT_IVF_PQ_PARAMS = new CuVSIvfPqParams.Builder().build();
+  public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
+  public static final int DEFAULT_GRAPH_DEGREE = 64;
+  public static final CagraGraphBuildAlgo DEFAULT_CAGRA_GRAPH_BUILD_ALGO =
+      CagraGraphBuildAlgo.NN_DESCENT;
+  public static final IndexType DEFAULT_INDEX_TYPE = IndexType.CAGRA;
+  public static final int DEFAULT_WRITER_THREADS = 1;
 
   private final int writerThreads;
   private final int intermediateGraphDegree;
   private final int graphdegree;
   private final CagraGraphBuildAlgo cagraGraphBuildAlgo;
   private final IndexType indexType;
+  private final CuVSIvfPqParams cuVSIvfPqParams;
 
   /**
    * Constructs an instance of {@link GPUSearchParams} with specific parameter values.
@@ -36,19 +46,22 @@ public class GPUSearchParams {
    * @param graphdegree The graph degree to use while building the CAGRA index.
    * @param cagraGraphBuildAlgo The CAGRA build algorithm to use.
    * @param indexType The type of index to build - CAGRA, BRUTEFORCE, or both.
+   * @param cuVSIvfPqParams An instance of CuVSIvfPqParams containing IVF_PQ specific parameters.
    */
   private GPUSearchParams(
       int writerThreads,
       int intermediateGraphDegree,
       int graphdegree,
       CagraGraphBuildAlgo cagraGraphBuildAlgo,
-      IndexType indexType) {
+      IndexType indexType,
+      CuVSIvfPqParams cuVSIvfPqParams) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
     this.graphdegree = graphdegree;
     this.cagraGraphBuildAlgo = cagraGraphBuildAlgo;
     this.indexType = indexType;
+    this.cuVSIvfPqParams = cuVSIvfPqParams;
   }
 
   /**
@@ -96,6 +109,15 @@ public class GPUSearchParams {
     return indexType;
   }
 
+  /**
+   * Get the instance of CuVSIvfPqParams
+   *
+   * @return an instance of CuVSIvfPqParams
+   */
+  public CuVSIvfPqParams getCuVSIvfPqParams() {
+    return cuVSIvfPqParams;
+  }
+
   @Override
   public String toString() {
     return "GPUSearchParams [writerThreads="
@@ -116,11 +138,12 @@ public class GPUSearchParams {
    */
   public static class Builder {
 
-    private int writerThreads = 1;
-    private int intermediateGraphDegree = 128;
-    private int graphdegree = 64;
-    private CagraGraphBuildAlgo cagraGraphBuildAlgo = CagraGraphBuildAlgo.NN_DESCENT;
-    private IndexType indexType = IndexType.CAGRA;
+    private int writerThreads = DEFAULT_WRITER_THREADS;
+    private int intermediateGraphDegree = DEFAULT_INT_GRAPH_DEGREE;
+    private int graphdegree = DEFAULT_GRAPH_DEGREE;
+    private CagraGraphBuildAlgo cagraGraphBuildAlgo = DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
+    private IndexType indexType = DEFAULT_INDEX_TYPE;
+    private CuVSIvfPqParams cuVSIvfPqParams = DEFAULT_IVF_PQ_PARAMS;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -186,6 +209,17 @@ public class GPUSearchParams {
     }
 
     /**
+     * Set the instance of {@link CuVSIvfPqParams}
+     *
+     * @param cuVSIvfPqParams
+     * @return instance of {@link Builder}
+     */
+    public Builder withCuVSIvfPqParams(CuVSIvfPqParams cuVSIvfPqParams) {
+      this.cuVSIvfPqParams = cuVSIvfPqParams;
+      return this;
+    }
+
+    /**
      * Validates the input parameters.
      *
      * @throws IllegalArgumentException
@@ -222,6 +256,9 @@ public class GPUSearchParams {
       if (Objects.isNull(indexType)) {
         throw new IllegalArgumentException("indexType cannot be null.");
       }
+      if (Objects.isNull(cuVSIvfPqParams)) {
+        throw new IllegalArgumentException("cuVSIvfPqParams cannot be null.");
+      }
     }
 
     /**
@@ -232,7 +269,12 @@ public class GPUSearchParams {
     public GPUSearchParams build() {
       validate();
       return new GPUSearchParams(
-          writerThreads, intermediateGraphDegree, graphdegree, cagraGraphBuildAlgo, indexType);
+          writerThreads,
+          intermediateGraphDegree,
+          graphdegree,
+          cagraGraphBuildAlgo,
+          indexType,
+          cuVSIvfPqParams);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/Utils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Utils.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.lucene.util.InfoStream;
 
 /**
  * This class provides common static utility methods.
@@ -167,5 +168,16 @@ public class Utils {
       return;
     }
     handleThrowable(t);
+  }
+
+  /**
+   * Utility to print info/debug messages via InfoStream.
+   *
+   * @param msg
+   */
+  static void info(InfoStream infoStream, String component, String msg) {
+    if (infoStream.isEnabled(component)) {
+      infoStream.message(component, msg);
+    }
   }
 }

--- a/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
@@ -76,13 +76,6 @@ public class TestGPUSearchParams extends LuceneTestCase {
         () -> new GPUSearchParams.Builder().withIndexType(null).build());
   }
 
-  @Test
-  public void testGPUSearchParamsInvalidCuVSIvfPqParams() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new GPUSearchParams.Builder().withCuVSIvfPqParams(null).build());
-  }
-
   @BeforeClass
   public static void beforeClass() {
     random = random();

--- a/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
@@ -5,8 +5,20 @@
 
 package com.nvidia.cuvs.lucene;
 
-import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
-import com.nvidia.cuvs.lucene.CuVS2510GPUVectorsWriter.IndexType;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INDEX_TYPE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_WRITER_THREADS;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_WRITER_THREADS;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_WRITER_THREADS;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Integer.MIN_VALUE;
+
 import java.util.Random;
 import java.util.logging.Logger;
 import org.apache.lucene.tests.util.LuceneTestCase;
@@ -25,17 +37,19 @@ public class TestGPUSearchParams extends LuceneTestCase {
   @Test
   public void testGPUSearchParamsDefaultValues() {
     GPUSearchParams params = new GPUSearchParams.Builder().build();
-    assertEquals(64, params.getGraphdegree());
-    assertEquals(128, params.getIntermediateGraphDegree());
-    assertEquals(1, params.getWriterThreads());
-    assertEquals(CagraGraphBuildAlgo.NN_DESCENT, params.getCagraGraphBuildAlgo());
-    assertEquals(IndexType.CAGRA, params.getIndexType());
+    assertEquals(DEFAULT_GRAPH_DEGREE, params.getGraphdegree());
+    assertEquals(DEFAULT_INT_GRAPH_DEGREE, params.getIntermediateGraphDegree());
+    assertEquals(DEFAULT_WRITER_THREADS, params.getWriterThreads());
+    assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
+    assertEquals(DEFAULT_INDEX_TYPE, params.getIndexType());
   }
 
   @Test
   public void testGPUSearchParamsInvalidGraphDegree() {
     for (int v :
-        new int[] {random.nextInt(Integer.MIN_VALUE, 1), random.nextInt(65, Integer.MAX_VALUE)}) {
+        new int[] {
+          random.nextInt(MIN_VALUE, MIN_GRAPH_DEG), random.nextInt(MAX_GRAPH_DEG + 1, MAX_VALUE)
+        }) {
       assertThrows(
           IllegalArgumentException.class,
           () -> new GPUSearchParams.Builder().withGraphDegree(v).build());
@@ -45,7 +59,10 @@ public class TestGPUSearchParams extends LuceneTestCase {
   @Test
   public void testGPUSearchParamsInvalidIntermediateGraphDegree() {
     for (int v :
-        new int[] {random.nextInt(Integer.MIN_VALUE, 1), random.nextInt(129, Integer.MAX_VALUE)}) {
+        new int[] {
+          random.nextInt(MIN_VALUE, MIN_INT_GRAPH_DEG),
+          random.nextInt(MAX_INT_GRAPH_DEG + 1, MAX_VALUE)
+        }) {
       assertThrows(
           IllegalArgumentException.class,
           () -> new GPUSearchParams.Builder().withIntermediateGraphDegree(v).build());
@@ -55,7 +72,10 @@ public class TestGPUSearchParams extends LuceneTestCase {
   @Test
   public void testGPUSearchParamsInvalidWriterThreads() {
     for (int v :
-        new int[] {random.nextInt(Integer.MIN_VALUE, 1), random.nextInt(2, Integer.MAX_VALUE)}) {
+        new int[] {
+          random.nextInt(MIN_VALUE, MIN_WRITER_THREADS),
+          random.nextInt(MAX_WRITER_THREADS + 1, MAX_VALUE)
+        }) {
       assertThrows(
           IllegalArgumentException.class,
           () -> new GPUSearchParams.Builder().withWriterThreads(v).build());

--- a/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
@@ -76,6 +76,13 @@ public class TestGPUSearchParams extends LuceneTestCase {
         () -> new GPUSearchParams.Builder().withIndexType(null).build());
   }
 
+  @Test
+  public void testGPUSearchParamsInvalidCuVSIvfPqParams() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new GPUSearchParams.Builder().withCuVSIvfPqParams(null).build());
+  }
+
   @BeforeClass
   public static void beforeClass() {
     random = random();


### PR DESCRIPTION
Fixes #125 

Summary of changes:
- Update `CuVS2510GPUVectorsFormat` to update variable names and rearrange stuff for readability.
- Update `CuVS2510GPUVectorsReader` to avoid loading of indexes on the GPU during merges to cut down on device memory usage, specifically during merges, fetch similarity functions via our provider instead of maintaining a list, implement `checkIntegrity` method, remove unused methods, update documentation, update search method to remove the existing workaround, and fix the prefiltering logic.
- Update `CuVS2510GPUVectorsWriter` to remove some unused code, variable renaming, ordering stuff for better readability, update documentation, remove some unnecessary checks, plug in num threads for brute force correctly, and remove some obsolete logic from `mergeOneField`. 
- Update `GPUSearchParams` mainly to allow passing `CuVSIvfPqParams`, some other minor updates.
- Update `Utils` to add a commonly used method.
- Thanks to James Xia for suggesting that the queries can be built on the device directly [0664f7f](https://github.com/rapidsai/cuvs-lucene/pull/126/commits/0664f7fc09d395a9aad4824253accaee35bd713e)