### PR TITLE
Introduce a heuristic approach to CAGRA build algorithm selection and its index parameters

### DIFF
--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -17,7 +17,7 @@ public class AcceleratedHNSWParams {
 
   public static enum Strategy {
     /*
-     * This strategy allows for automatic selection of the underlining CAGRA build algorithm.
+     * This strategy allows for automatic selection of the underlying CAGRA build algorithm.
      * With this strategy we use NN_DESCENT for data set less then 5M vectors else we use IVF_PQ.
      * Indexing parameters, especially for IVF_PQ, are heuristically identified automatically.
      *

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -490,6 +490,9 @@ public class AcceleratedHNSWParams {
     /**
      * Set the value of m - defines the maximum number of bi-directional links (edges) per node
      *
+     * Valid range - Minimum: {@value MIN_M}, Maximum: {@value MAX_M}
+     * Default value - {@value DEFAULT_M}
+     *
      * @param m, the value to set
      * @return instance of {@link Builder}
      */
@@ -500,6 +503,9 @@ public class AcceleratedHNSWParams {
 
     /**
      * Set the value of efConstruction - determines the size of the dynamic candidate list during graph construction
+     *
+     * Valid range - Minimum: {@value MIN_EF_CONSTRUCTION}, Maximum: {@value MAX_EF_CONSTRUCTION}
+     * Default value - {@value DEFAULT_EF_CONSTRUCTION}
      *
      * @param efConstruction, the value to set
      * @return instance of {@link Builder}
@@ -514,6 +520,9 @@ public class AcceleratedHNSWParams {
      *
      * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
      * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+     *
+     * Valid options - HEURISTIC, CUSTOM
+     * Default value - HEURISTIC
      *
      * @param strategy, the strategy to choose
      * @return instance of {@link Builder}

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -105,7 +105,7 @@ public class AcceleratedHNSWParams {
    * @param mergeExec The instance of {@link ExecutorService} to use with the fallback mechanism.
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
    * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
-   * @param nNDescentNumIterations the number of Iterations to run if building with NN_DESCENT.
+   * @param nnDescentNumIterations the number of Iterations to run if building with NN_DESCENT.
    */
   private AcceleratedHNSWParams(
       int writerThreads,

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -49,10 +49,8 @@ public class AcceleratedHNSWParams {
   public static final int MAX_BEAM_WIDTH = 512;
   public static final int MIN_NUM_MERGE_WORKERS = 1;
   public static final int MAX_NUM_MERGE_WORKERS = 512;
-  public static final int MIN_M = 1;
-  public static final int MAX_M = 1024;
-  public static final int MIN_EF_CONSTRUCTION = 1;
-  public static final int MAX_EF_CONSTRUCTION = 1024;
+  public static final long MIN_NN_DESCENT_NUM_ITERATIONS = 1;
+  public static final long MAX_NN_DESCENT_NUM_ITERATIONS = 100;
 
   public static final int DEFAULT_WRITER_THREADS = 1;
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
@@ -65,6 +63,7 @@ public class AcceleratedHNSWParams {
   public static final int DEFAULT_NUM_MERGE_WORKERS = 1;
   public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
   public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
+  public static final long DEFAULT_NN_DESCENT_NUM_ITERATIONS = 20;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
       () -> {
@@ -88,6 +87,7 @@ public class AcceleratedHNSWParams {
   private final ExecutorService mergeExec;
   private final Strategy strategy;
   private final CuvsDistanceType cuvsDistanceType;
+  private final long nNDescentNumIterations;
 
   /**
    * Constructs an instance of {@link AcceleratedHNSWParams} with specific parameter values.
@@ -105,6 +105,7 @@ public class AcceleratedHNSWParams {
    * @param mergeExec The instance of {@link ExecutorService} to use with the fallback mechanism.
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
    * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
+   * @param nNDescentNumIterations the number of Iterations to run if building with NN_DESCENT.
    */
   private AcceleratedHNSWParams(
       int writerThreads,
@@ -118,7 +119,8 @@ public class AcceleratedHNSWParams {
       int numMergeWorkers,
       ExecutorService mergeExec,
       Strategy strategy,
-      CuvsDistanceType cuvsDistanceType) {
+      CuvsDistanceType cuvsDistanceType,
+      long nNDescentNumIterations) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
@@ -132,6 +134,7 @@ public class AcceleratedHNSWParams {
     this.mergeExec = mergeExec;
     this.strategy = strategy;
     this.cuvsDistanceType = cuvsDistanceType;
+    this.nNDescentNumIterations = nNDescentNumIterations;
   }
 
   /**
@@ -245,6 +248,15 @@ public class AcceleratedHNSWParams {
     return cuvsDistanceType;
   }
 
+  /**
+   * get the number of Iterations to run if building with NN_DESCENT
+   *
+   * @return the number of iterations for NN_DESCENT
+   */
+  public long getnNDescentNumIterations() {
+    return nNDescentNumIterations;
+  }
+
   @Override
   public String toString() {
     return "AcceleratedHNSWParams [writerThreads="
@@ -271,6 +283,8 @@ public class AcceleratedHNSWParams {
         + strategy
         + ", cuvsDistanceType="
         + cuvsDistanceType
+        + ", nNDescentNumIterations="
+        + nNDescentNumIterations
         + "]";
   }
 
@@ -291,6 +305,7 @@ public class AcceleratedHNSWParams {
     private ExecutorService mergeExec = null;
     private Strategy strategy = DEFAULT_STRATEGY;
     private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
+    private long nNDescentNumIterations = DEFAULT_NN_DESCENT_NUM_ITERATIONS;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -446,6 +461,20 @@ public class AcceleratedHNSWParams {
     }
 
     /**
+     * Set the number of Iterations to run if building with NN_DESCENT
+     *
+     * Valid range - Minimum: {@value MIN_NN_DESCENT_NUM_ITERATIONS}, Maximum: {@value MAX_NN_DESCENT_NUM_ITERATIONS}
+     * Default value - {@value DEFAULT_NN_DESCENT_NUM_ITERATIONS}
+     *
+     * @param nNDescentNumIterations number of merge workers to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withNNDescentNumIterations(int nNDescentNumIterations) {
+      this.nNDescentNumIterations = nNDescentNumIterations;
+      return this;
+    }
+
+    /**
      * Validates the input parameters.
      *
      * @throws IllegalArgumentException
@@ -517,6 +546,15 @@ public class AcceleratedHNSWParams {
       if (Objects.isNull(cuvsDistanceType)) {
         throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
       }
+      if (nNDescentNumIterations < MIN_NN_DESCENT_NUM_ITERATIONS
+          || nNDescentNumIterations > MAX_NN_DESCENT_NUM_ITERATIONS) {
+        throw new IllegalArgumentException(
+            "nNDescentNumIterations not in valid range. Valid range: ["
+                + MIN_NN_DESCENT_NUM_ITERATIONS
+                + ", "
+                + MAX_NN_DESCENT_NUM_ITERATIONS
+                + "]");
+      }
     }
 
     /**
@@ -544,7 +582,8 @@ public class AcceleratedHNSWParams {
           numMergeWorkers,
           mergeExec,
           strategy,
-          cuvsDistanceType);
+          cuvsDistanceType,
+          nNDescentNumIterations);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -9,7 +9,6 @@ import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
 import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
 import com.nvidia.cuvs.CagraIndexParams.HnswHeuristicType;
 import com.nvidia.cuvs.CuVSIvfPqParams;
-import com.nvidia.cuvs.lucene.GPUSearchParams.Builder;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -18,7 +17,35 @@ import java.util.function.Supplier;
 public class AcceleratedHNSWParams {
 
   public static enum Strategy {
+    /*
+     * This strategy allows for automatic selection of the underlining build algorithm for CAGRA.
+     * As per the currently chosen threshold we choose NN_DESCENT under 1M vectors.
+     * For 1M vectors, we switch to IVF_PQ algorithm. Also for both algorithms the input parameters
+     * are heuristically assessed internally in the cuvs layer.
+     *
+     * When using this strategy only the following parameters are effective and can be overridden:
+     * - m
+     * - efConstruction
+     * - heuristicType
+     * - cuvsDistanceType
+     * - writerThreads
+     *
+     * This is the default and the recommended strategy.
+     */
     HEURISTIC,
+    /*
+     * This is an option when the end-user would want to use custom parameter values.
+     *
+     * When using this strategy only the following parameters are effective and can be overridden:
+     * - intermediateGraphDegree
+     * - graphdegree
+     * - cagraGraphBuildAlgo
+     * - indexType
+     * - cuVSIvfPqParams
+     * - writerThreads
+     *
+     * This strategy should only be used under expert guidance.
+     */
     CUSTOM
   }
 
@@ -104,8 +131,8 @@ public class AcceleratedHNSWParams {
    * @param m defines The maximum number of bi-directional links (edges) per node.
    * @param efConstruction Determines the size of the dynamic candidate list during graph construction.
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
-   * @param heuristicType
-   * @param cuvsDistanceType
+   * @param heuristicType the heuristic type. The default option is SAME_GRAPH_FOOTPRINT.
+   * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
    */
   private AcceleratedHNSWParams(
       int writerThreads,
@@ -499,7 +526,7 @@ public class AcceleratedHNSWParams {
     /**
      * Set the HnswHeuristicType
      *
-     * @param the HnswHeuristicType to set
+     * @param heuristicType the HnswHeuristicType to set
      * @return instance of {@link Builder}
      */
     public Builder withHeuristicType(HnswHeuristicType heuristicType) {
@@ -510,7 +537,7 @@ public class AcceleratedHNSWParams {
     /**
      * Set the CuvsDistanceType
      *
-     * @param the CuvsDistanceType to set
+     * @param cuvsDistanceType the CuvsDistanceType to set
      * @return instance of {@link Builder}
      */
     public Builder withCuvsDistanceType(CuvsDistanceType cuvsDistanceType) {

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -7,7 +7,6 @@ package com.nvidia.cuvs.lucene;
 
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
 import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
-import com.nvidia.cuvs.CagraIndexParams.HnswHeuristicType;
 import com.nvidia.cuvs.CuVSIvfPqParams;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -18,32 +17,15 @@ public class AcceleratedHNSWParams {
 
   public static enum Strategy {
     /*
-     * This strategy allows for automatic selection of the underlining build algorithm for CAGRA.
-     * As per the currently chosen threshold we choose NN_DESCENT under 1M vectors.
-     * For 1M vectors, we switch to IVF_PQ algorithm. Also for both algorithms the input parameters
-     * are heuristically assessed internally in the cuvs layer.
-     *
-     * When using this strategy only the following parameters are effective and can be overridden:
-     * - m
-     * - efConstruction
-     * - heuristicType
-     * - cuvsDistanceType
-     * - writerThreads
+     * This strategy allows for automatic selection of the underlining CAGRA build algorithm.
+     * With this strategy we use NN_DESCENT for data set less then 5M vectors else we use IVF_PQ.
+     * Indexing parameters, especially for IVF_PQ, are heuristically identified automatically.
      *
      * This is the default and the recommended strategy.
      */
     HEURISTIC,
     /*
      * This is an option when the end-user would want to use custom parameter values.
-     *
-     * When using this strategy only the following parameters are effective and can be overridden:
-     * - intermediateGraphDegree
-     * - graphdegree
-     * - cagraGraphBuildAlgo
-     * - indexType
-     * - cuVSIvfPqParams
-     * - writerThreads
-     *
      * This strategy should only be used under expert guidance.
      */
     CUSTOM
@@ -81,11 +63,7 @@ public class AcceleratedHNSWParams {
   public static final CagraGraphBuildAlgo DEFAULT_CAGRA_GRAPH_BUILD_ALGO =
       CagraGraphBuildAlgo.NN_DESCENT;
   public static final int DEFAULT_NUM_MERGE_WORKERS = 1;
-  public static final int DEFAULT_M = 16;
-  public static final int DEFAULT_EF_CONSTRUCTION = 16;
   public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
-  public static final HnswHeuristicType DEFAULT_HEURISTIC_TYPE =
-      HnswHeuristicType.SAME_GRAPH_FOOTPRINT;
   public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
@@ -108,10 +86,7 @@ public class AcceleratedHNSWParams {
   private final CuVSIvfPqParams cuVSIvfPqParams;
   private final int numMergeWorkers;
   private final ExecutorService mergeExec;
-  private final int m;
-  private final int efConstruction;
   private final Strategy strategy;
-  private final HnswHeuristicType heuristicType;
   private final CuvsDistanceType cuvsDistanceType;
 
   /**
@@ -128,10 +103,7 @@ public class AcceleratedHNSWParams {
    * @param cuVSIvfPqParams An instance of CuVSIvfPqParams containing IVF_PQ specific parameters.
    * @param numMergeWorkers The number of merge workers to use with the fallback mechanism.
    * @param mergeExec The instance of {@link ExecutorService} to use with the fallback mechanism.
-   * @param m defines The maximum number of bi-directional links (edges) per node.
-   * @param efConstruction Determines the size of the dynamic candidate list during graph construction.
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
-   * @param heuristicType the heuristic type. The default option is SAME_GRAPH_FOOTPRINT.
    * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
    */
   private AcceleratedHNSWParams(
@@ -145,10 +117,7 @@ public class AcceleratedHNSWParams {
       CuVSIvfPqParams cuVSIvfPqParams,
       int numMergeWorkers,
       ExecutorService mergeExec,
-      int m,
-      int efConstruction,
       Strategy strategy,
-      HnswHeuristicType heuristicType,
       CuvsDistanceType cuvsDistanceType) {
     super();
     this.writerThreads = writerThreads;
@@ -161,10 +130,7 @@ public class AcceleratedHNSWParams {
     this.cuVSIvfPqParams = cuVSIvfPqParams;
     this.numMergeWorkers = numMergeWorkers;
     this.mergeExec = mergeExec;
-    this.m = m;
-    this.efConstruction = efConstruction;
     this.strategy = strategy;
-    this.heuristicType = heuristicType;
     this.cuvsDistanceType = cuvsDistanceType;
   }
 
@@ -259,24 +225,6 @@ public class AcceleratedHNSWParams {
   }
 
   /**
-   * Get the value of m - defines the maximum number of bi-directional links (edges) per node
-   *
-   * @return the value of m
-   */
-  public int getM() {
-    return m;
-  }
-
-  /**
-   * Get the value of efConstruction - determines the size of the dynamic candidate list during graph construction
-   *
-   * @return the value of efConstruction
-   */
-  public int getEfConstruction() {
-    return efConstruction;
-  }
-
-  /**
    * Get the chosen strategy:
    *
    * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
@@ -286,15 +234,6 @@ public class AcceleratedHNSWParams {
    */
   public Strategy getStrategy() {
     return strategy;
-  }
-
-  /**
-   * Get the heuristic type
-   *
-   * @return the heuristic type
-   */
-  public HnswHeuristicType getHeuristicType() {
-    return heuristicType;
   }
 
   /**
@@ -328,14 +267,8 @@ public class AcceleratedHNSWParams {
         + numMergeWorkers
         + ", mergeExec="
         + mergeExec
-        + ", m="
-        + m
-        + ", efConstruction="
-        + efConstruction
         + ", strategy="
         + strategy
-        + ", heuristicType="
-        + heuristicType
         + ", cuvsDistanceType="
         + cuvsDistanceType
         + "]";
@@ -356,10 +289,7 @@ public class AcceleratedHNSWParams {
     private int numMergeWorkers = DEFAULT_NUM_MERGE_WORKERS;
     private CuVSIvfPqParams cuVSIvfPqParams = null;
     private ExecutorService mergeExec = null;
-    private int m = DEFAULT_M;
-    private int efConstruction = DEFAULT_EF_CONSTRUCTION;
     private Strategy strategy = DEFAULT_STRATEGY;
-    private HnswHeuristicType heuristicType = DEFAULT_HEURISTIC_TYPE;
     private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
 
     /**
@@ -488,34 +418,6 @@ public class AcceleratedHNSWParams {
     }
 
     /**
-     * Set the value of m - defines the maximum number of bi-directional links (edges) per node
-     *
-     * Valid range - Minimum: {@value MIN_M}, Maximum: {@value MAX_M}
-     * Default value - {@value DEFAULT_M}
-     *
-     * @param m, the value to set
-     * @return instance of {@link Builder}
-     */
-    public Builder withM(int m) {
-      this.m = m;
-      return this;
-    }
-
-    /**
-     * Set the value of efConstruction - determines the size of the dynamic candidate list during graph construction
-     *
-     * Valid range - Minimum: {@value MIN_EF_CONSTRUCTION}, Maximum: {@value MAX_EF_CONSTRUCTION}
-     * Default value - {@value DEFAULT_EF_CONSTRUCTION}
-     *
-     * @param efConstruction, the value to set
-     * @return instance of {@link Builder}
-     */
-    public Builder withEfConstruction(int efConstruction) {
-      this.efConstruction = efConstruction;
-      return this;
-    }
-
-    /**
      * Set the chosen strategy:
      *
      * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
@@ -529,17 +431,6 @@ public class AcceleratedHNSWParams {
      */
     public Builder withStrategy(Strategy strategy) {
       this.strategy = strategy;
-      return this;
-    }
-
-    /**
-     * Set the HnswHeuristicType
-     *
-     * @param heuristicType the HnswHeuristicType to set
-     * @return instance of {@link Builder}
-     */
-    public Builder withHeuristicType(HnswHeuristicType heuristicType) {
-      this.heuristicType = heuristicType;
       return this;
     }
 
@@ -620,23 +511,8 @@ public class AcceleratedHNSWParams {
                 + MAX_NUM_MERGE_WORKERS
                 + "]");
       }
-      if (m < MIN_M || m > MAX_M) {
-        throw new IllegalArgumentException(
-            "m not in valid range. Valid range: [" + MIN_M + ", " + MAX_M + "]");
-      }
-      if (efConstruction < MIN_EF_CONSTRUCTION || efConstruction > MAX_EF_CONSTRUCTION) {
-        throw new IllegalArgumentException(
-            "efConstruction not in valid range. Valid range: ["
-                + MIN_EF_CONSTRUCTION
-                + ", "
-                + MAX_EF_CONSTRUCTION
-                + "]");
-      }
       if (Objects.isNull(strategy)) {
         throw new IllegalArgumentException("strategy cannot be null.");
-      }
-      if (Objects.isNull(heuristicType)) {
-        throw new IllegalArgumentException("heuristicType cannot be null.");
       }
       if (Objects.isNull(cuvsDistanceType)) {
         throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
@@ -667,10 +543,7 @@ public class AcceleratedHNSWParams {
           cuVSIvfPqParams,
           numMergeWorkers,
           mergeExec,
-          m,
-          efConstruction,
           strategy,
-          heuristicType,
           cuvsDistanceType);
     }
   }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -6,13 +6,21 @@
 package com.nvidia.cuvs.lucene;
 
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
+import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
+import com.nvidia.cuvs.CagraIndexParams.HnswHeuristicType;
 import com.nvidia.cuvs.CuVSIvfPqParams;
+import com.nvidia.cuvs.lucene.GPUSearchParams.Builder;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 public class AcceleratedHNSWParams {
+
+  public static enum Strategy {
+    HEURISTIC,
+    CUSTOM
+  }
 
   /*
    * TODO: Update boundaries for all parameters when a consensus is reached.
@@ -32,6 +40,10 @@ public class AcceleratedHNSWParams {
   public static final int MAX_BEAM_WIDTH = 512;
   public static final int MIN_NUM_MERGE_WORKERS = 1;
   public static final int MAX_NUM_MERGE_WORKERS = 512;
+  public static final int MIN_M = 1;
+  public static final int MAX_M = 1024;
+  public static final int MIN_EF_CONSTRUCTION = 1;
+  public static final int MAX_EF_CONSTRUCTION = 1024;
 
   public static final int DEFAULT_WRITER_THREADS = 1;
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
@@ -42,6 +54,12 @@ public class AcceleratedHNSWParams {
   public static final CagraGraphBuildAlgo DEFAULT_CAGRA_GRAPH_BUILD_ALGO =
       CagraGraphBuildAlgo.NN_DESCENT;
   public static final int DEFAULT_NUM_MERGE_WORKERS = 1;
+  public static final int DEFAULT_M = 16;
+  public static final int DEFAULT_EF_CONSTRUCTION = 16;
+  public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
+  public static final HnswHeuristicType DEFAULT_HEURISTIC_TYPE =
+      HnswHeuristicType.SAME_GRAPH_FOOTPRINT;
+  public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
       () -> {
@@ -63,6 +81,11 @@ public class AcceleratedHNSWParams {
   private final CuVSIvfPqParams cuVSIvfPqParams;
   private final int numMergeWorkers;
   private final ExecutorService mergeExec;
+  private final int m;
+  private final int efConstruction;
+  private final Strategy strategy;
+  private final HnswHeuristicType heuristicType;
+  private final CuvsDistanceType cuvsDistanceType;
 
   /**
    * Constructs an instance of {@link AcceleratedHNSWParams} with specific parameter values.
@@ -78,6 +101,11 @@ public class AcceleratedHNSWParams {
    * @param cuVSIvfPqParams An instance of CuVSIvfPqParams containing IVF_PQ specific parameters.
    * @param numMergeWorkers The number of merge workers to use with the fallback mechanism.
    * @param mergeExec The instance of {@link ExecutorService} to use with the fallback mechanism.
+   * @param m defines The maximum number of bi-directional links (edges) per node.
+   * @param efConstruction Determines the size of the dynamic candidate list during graph construction.
+   * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
+   * @param heuristicType
+   * @param cuvsDistanceType
    */
   private AcceleratedHNSWParams(
       int writerThreads,
@@ -89,7 +117,12 @@ public class AcceleratedHNSWParams {
       CagraGraphBuildAlgo cagraGraphBuildAlgo,
       CuVSIvfPqParams cuVSIvfPqParams,
       int numMergeWorkers,
-      ExecutorService mergeExec) {
+      ExecutorService mergeExec,
+      int m,
+      int efConstruction,
+      Strategy strategy,
+      HnswHeuristicType heuristicType,
+      CuvsDistanceType cuvsDistanceType) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
@@ -101,6 +134,11 @@ public class AcceleratedHNSWParams {
     this.cuVSIvfPqParams = cuVSIvfPqParams;
     this.numMergeWorkers = numMergeWorkers;
     this.mergeExec = mergeExec;
+    this.m = m;
+    this.efConstruction = efConstruction;
+    this.strategy = strategy;
+    this.heuristicType = heuristicType;
+    this.cuvsDistanceType = cuvsDistanceType;
   }
 
   /**
@@ -193,6 +231,54 @@ public class AcceleratedHNSWParams {
     return mergeExec;
   }
 
+  /**
+   * Get the value of m - defines the maximum number of bi-directional links (edges) per node
+   *
+   * @return the value of m
+   */
+  public int getM() {
+    return m;
+  }
+
+  /**
+   * Get the value of efConstruction - determines the size of the dynamic candidate list during graph construction
+   *
+   * @return the value of efConstruction
+   */
+  public int getEfConstruction() {
+    return efConstruction;
+  }
+
+  /**
+   * Get the chosen strategy:
+   *
+   * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
+   * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+   *
+   * @return get the chosen {@link Strategy}
+   */
+  public Strategy getStrategy() {
+    return strategy;
+  }
+
+  /**
+   * Get the heuristic type
+   *
+   * @return the heuristic type
+   */
+  public HnswHeuristicType getHeuristicType() {
+    return heuristicType;
+  }
+
+  /**
+   * Get the cuvs distance type
+   *
+   * @return the distance type
+   */
+  public CuvsDistanceType getCuvsDistanceType() {
+    return cuvsDistanceType;
+  }
+
   @Override
   public String toString() {
     return "AcceleratedHNSWParams [writerThreads="
@@ -209,10 +295,22 @@ public class AcceleratedHNSWParams {
         + beamWidth
         + ", cagraGraphBuildAlgo="
         + cagraGraphBuildAlgo
+        + ", cuVSIvfPqParams="
+        + cuVSIvfPqParams
         + ", numMergeWorkers="
         + numMergeWorkers
         + ", mergeExec="
         + mergeExec
+        + ", m="
+        + m
+        + ", efConstruction="
+        + efConstruction
+        + ", strategy="
+        + strategy
+        + ", heuristicType="
+        + heuristicType
+        + ", cuvsDistanceType="
+        + cuvsDistanceType
         + "]";
   }
 
@@ -231,6 +329,11 @@ public class AcceleratedHNSWParams {
     private int numMergeWorkers = DEFAULT_NUM_MERGE_WORKERS;
     private CuVSIvfPqParams cuVSIvfPqParams = null;
     private ExecutorService mergeExec = null;
+    private int m = DEFAULT_M;
+    private int efConstruction = DEFAULT_EF_CONSTRUCTION;
+    private Strategy strategy = DEFAULT_STRATEGY;
+    private HnswHeuristicType heuristicType = DEFAULT_HEURISTIC_TYPE;
+    private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -358,6 +461,64 @@ public class AcceleratedHNSWParams {
     }
 
     /**
+     * Set the value of m - defines the maximum number of bi-directional links (edges) per node
+     *
+     * @param m, the value to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withM(int m) {
+      this.m = m;
+      return this;
+    }
+
+    /**
+     * Set the value of efConstruction - determines the size of the dynamic candidate list during graph construction
+     *
+     * @param efConstruction, the value to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withEfConstruction(int efConstruction) {
+      this.efConstruction = efConstruction;
+      return this;
+    }
+
+    /**
+     * Set the chosen strategy:
+     *
+     * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
+     * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+     *
+     * @param strategy, the strategy to choose
+     * @return instance of {@link Builder}
+     */
+    public Builder withStrategy(Strategy strategy) {
+      this.strategy = strategy;
+      return this;
+    }
+
+    /**
+     * Set the HnswHeuristicType
+     *
+     * @param the HnswHeuristicType to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withHeuristicType(HnswHeuristicType heuristicType) {
+      this.heuristicType = heuristicType;
+      return this;
+    }
+
+    /**
+     * Set the CuvsDistanceType
+     *
+     * @param the CuvsDistanceType to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withCuvsDistanceType(CuvsDistanceType cuvsDistanceType) {
+      this.cuvsDistanceType = cuvsDistanceType;
+      return this;
+    }
+
+    /**
      * Validates the input parameters.
      *
      * @throws IllegalArgumentException
@@ -423,6 +584,27 @@ public class AcceleratedHNSWParams {
                 + MAX_NUM_MERGE_WORKERS
                 + "]");
       }
+      if (m < MIN_M || m > MAX_M) {
+        throw new IllegalArgumentException(
+            "m not in valid range. Valid range: [" + MIN_M + ", " + MAX_M + "]");
+      }
+      if (efConstruction < MIN_EF_CONSTRUCTION || efConstruction > MAX_EF_CONSTRUCTION) {
+        throw new IllegalArgumentException(
+            "efConstruction not in valid range. Valid range: ["
+                + MIN_EF_CONSTRUCTION
+                + ", "
+                + MAX_EF_CONSTRUCTION
+                + "]");
+      }
+      if (Objects.isNull(strategy)) {
+        throw new IllegalArgumentException("strategy cannot be null.");
+      }
+      if (Objects.isNull(heuristicType)) {
+        throw new IllegalArgumentException("heuristicType cannot be null.");
+      }
+      if (Objects.isNull(cuvsDistanceType)) {
+        throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
+      }
     }
 
     /**
@@ -448,7 +630,12 @@ public class AcceleratedHNSWParams {
           cagraGraphBuildAlgo,
           cuVSIvfPqParams,
           numMergeWorkers,
-          mergeExec);
+          mergeExec,
+          m,
+          efConstruction,
+          strategy,
+          heuristicType,
+          cuvsDistanceType);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -18,7 +18,7 @@ public class AcceleratedHNSWParams {
   public static enum Strategy {
     /*
      * This strategy allows for automatic selection of the underlying CAGRA build algorithm.
-     * With this strategy we use NN_DESCENT for data set less then 5M vectors else we use IVF_PQ.
+     * With this strategy we use NN_DESCENT for dataset less than 5M vectors, else we use IVF_PQ.
      * Indexing parameters, especially for IVF_PQ, are heuristically identified automatically.
      *
      * This is the default and the recommended strategy.

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -49,8 +49,8 @@ public class AcceleratedHNSWParams {
   public static final int MAX_BEAM_WIDTH = 512;
   public static final int MIN_NUM_MERGE_WORKERS = 1;
   public static final int MAX_NUM_MERGE_WORKERS = 512;
-  public static final long MIN_NN_DESCENT_NUM_ITERATIONS = 1;
-  public static final long MAX_NN_DESCENT_NUM_ITERATIONS = 100;
+  public static final int MIN_NN_DESCENT_NUM_ITERATIONS = 1;
+  public static final int MAX_NN_DESCENT_NUM_ITERATIONS = 100;
 
   public static final int DEFAULT_WRITER_THREADS = 1;
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
@@ -63,7 +63,7 @@ public class AcceleratedHNSWParams {
   public static final int DEFAULT_NUM_MERGE_WORKERS = 1;
   public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
   public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
-  public static final long DEFAULT_NN_DESCENT_NUM_ITERATIONS = 20;
+  public static final int DEFAULT_NN_DESCENT_NUM_ITERATIONS = 20;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
       () -> {
@@ -87,7 +87,7 @@ public class AcceleratedHNSWParams {
   private final ExecutorService mergeExec;
   private final Strategy strategy;
   private final CuvsDistanceType cuvsDistanceType;
-  private final long nNDescentNumIterations;
+  private final int nnDescentNumIterations;
 
   /**
    * Constructs an instance of {@link AcceleratedHNSWParams} with specific parameter values.
@@ -120,7 +120,7 @@ public class AcceleratedHNSWParams {
       ExecutorService mergeExec,
       Strategy strategy,
       CuvsDistanceType cuvsDistanceType,
-      long nNDescentNumIterations) {
+      int nnDescentNumIterations) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
@@ -134,7 +134,7 @@ public class AcceleratedHNSWParams {
     this.mergeExec = mergeExec;
     this.strategy = strategy;
     this.cuvsDistanceType = cuvsDistanceType;
-    this.nNDescentNumIterations = nNDescentNumIterations;
+    this.nnDescentNumIterations = nnDescentNumIterations;
   }
 
   /**
@@ -253,8 +253,8 @@ public class AcceleratedHNSWParams {
    *
    * @return the number of iterations for NN_DESCENT
    */
-  public long getnNDescentNumIterations() {
-    return nNDescentNumIterations;
+  public int getNNDescentNumIterations() {
+    return nnDescentNumIterations;
   }
 
   @Override
@@ -283,8 +283,8 @@ public class AcceleratedHNSWParams {
         + strategy
         + ", cuvsDistanceType="
         + cuvsDistanceType
-        + ", nNDescentNumIterations="
-        + nNDescentNumIterations
+        + ", nnDescentNumIterations="
+        + nnDescentNumIterations
         + "]";
   }
 
@@ -305,7 +305,7 @@ public class AcceleratedHNSWParams {
     private ExecutorService mergeExec = null;
     private Strategy strategy = DEFAULT_STRATEGY;
     private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
-    private long nNDescentNumIterations = DEFAULT_NN_DESCENT_NUM_ITERATIONS;
+    private int nnDescentNumIterations = DEFAULT_NN_DESCENT_NUM_ITERATIONS;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -466,11 +466,11 @@ public class AcceleratedHNSWParams {
      * Valid range - Minimum: {@value MIN_NN_DESCENT_NUM_ITERATIONS}, Maximum: {@value MAX_NN_DESCENT_NUM_ITERATIONS}
      * Default value - {@value DEFAULT_NN_DESCENT_NUM_ITERATIONS}
      *
-     * @param nNDescentNumIterations number of merge workers to set
+     * @param nnDescentNumIterations number of merge workers to set
      * @return instance of {@link Builder}
      */
-    public Builder withNNDescentNumIterations(int nNDescentNumIterations) {
-      this.nNDescentNumIterations = nNDescentNumIterations;
+    public Builder withNNDescentNumIterations(int nnDescentNumIterations) {
+      this.nnDescentNumIterations = nnDescentNumIterations;
       return this;
     }
 
@@ -546,10 +546,10 @@ public class AcceleratedHNSWParams {
       if (Objects.isNull(cuvsDistanceType)) {
         throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
       }
-      if (nNDescentNumIterations < MIN_NN_DESCENT_NUM_ITERATIONS
-          || nNDescentNumIterations > MAX_NN_DESCENT_NUM_ITERATIONS) {
+      if (nnDescentNumIterations < MIN_NN_DESCENT_NUM_ITERATIONS
+          || nnDescentNumIterations > MAX_NN_DESCENT_NUM_ITERATIONS) {
         throw new IllegalArgumentException(
-            "nNDescentNumIterations not in valid range. Valid range: ["
+            "nnDescentNumIterations not in valid range. Valid range: ["
                 + MIN_NN_DESCENT_NUM_ITERATIONS
                 + ", "
                 + MAX_NN_DESCENT_NUM_ITERATIONS
@@ -583,7 +583,7 @@ public class AcceleratedHNSWParams {
           mergeExec,
           strategy,
           cuvsDistanceType,
-          nNDescentNumIterations);
+          nnDescentNumIterations);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -10,10 +10,9 @@ import static com.nvidia.cuvs.lucene.Utils.createByteMatrixFromArray;
 
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CagraIndexParams;
-import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
-import com.nvidia.cuvs.CuVSIvfPqParams;
 import com.nvidia.cuvs.CuVSMatrix;
 import com.nvidia.cuvs.RowView;
+import com.nvidia.cuvs.lucene.AcceleratedHNSWParams.Strategy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -400,26 +399,6 @@ public class AcceleratedHNSWUtils {
   }
 
   /**
-   * Builds an instance of CagraIndexParams.
-   *
-   * @return instance of CagraIndexParams
-   */
-  public static CagraIndexParams cagraIndexParams(
-      int cuvsWriterThreads,
-      int intGraphDegree,
-      int graphDegree,
-      CagraGraphBuildAlgo cagraGraphBuildAlgo,
-      CuVSIvfPqParams cuVSIvfPqParams) {
-    return new CagraIndexParams.Builder()
-        .withNumWriterThreads(cuvsWriterThreads)
-        .withIntermediateGraphDegree(intGraphDegree)
-        .withGraphDegree(graphDegree)
-        .withCagraGraphBuildAlgo(cagraGraphBuildAlgo)
-        .withCuVSIvfPqParams(cuVSIvfPqParams)
-        .build();
-  }
-
-  /**
    * Quantizes FLOAT32 vectors to binary (1 bit per dimension, packed into bytes).
    * Binary quantization: each dimension is compared to a centroid (mean of all values for that dimension).
    * If value > centroid, bit = 1, else bit = 0.
@@ -507,5 +486,35 @@ public class AcceleratedHNSWUtils {
     }
 
     return quantizedVectors;
+  }
+
+  /**
+   * Get an instance of {@link CagraIndexParams} based on the chosen {@link Strategy}
+   *
+   * @param acceleratedHNSWParams instance of the {@link AcceleratedHNSWParams}
+   * @param rows the number of vectors in the data set
+   * @param dimension the vector dimension
+   *
+   * @return an instance of {@link CagraIndexParams}
+   */
+  public static CagraIndexParams getCagraIndexParams(
+      AcceleratedHNSWParams acceleratedHNSWParams, long rows, long dimension) {
+    if (acceleratedHNSWParams.getStrategy().equals(Strategy.HEURISTIC)) {
+      return CagraIndexParams.fromHnswParams(
+          rows,
+          dimension,
+          acceleratedHNSWParams.getM(),
+          acceleratedHNSWParams.getEfConstruction(),
+          acceleratedHNSWParams.getHeuristicType(),
+          acceleratedHNSWParams.getCuvsDistanceType());
+    } else {
+      return new CagraIndexParams.Builder()
+          .withNumWriterThreads(acceleratedHNSWParams.getWriterThreads())
+          .withIntermediateGraphDegree(acceleratedHNSWParams.getIntermediateGraphDegree())
+          .withGraphDegree(acceleratedHNSWParams.getGraphdegree())
+          .withCagraGraphBuildAlgo(acceleratedHNSWParams.getCagraGraphBuildAlgo())
+          .withCuVSIvfPqParams(acceleratedHNSWParams.getCuVSIvfPqParams())
+          .build();
+    }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -499,22 +499,6 @@ public class AcceleratedHNSWUtils {
    */
   public static CagraIndexParams getCagraIndexParams(
       AcceleratedHNSWParams acceleratedHNSWParams, long rows, long dimension) {
-    if (acceleratedHNSWParams.getStrategy().equals(Strategy.HEURISTIC)) {
-      return CagraIndexParams.fromHnswParams(
-          rows,
-          dimension,
-          acceleratedHNSWParams.getM(),
-          acceleratedHNSWParams.getEfConstruction(),
-          acceleratedHNSWParams.getHeuristicType(),
-          acceleratedHNSWParams.getCuvsDistanceType());
-    } else {
-      return new CagraIndexParams.Builder()
-          .withNumWriterThreads(acceleratedHNSWParams.getWriterThreads())
-          .withIntermediateGraphDegree(acceleratedHNSWParams.getIntermediateGraphDegree())
-          .withGraphDegree(acceleratedHNSWParams.getGraphdegree())
-          .withCagraGraphBuildAlgo(acceleratedHNSWParams.getCagraGraphBuildAlgo())
-          .withCuVSIvfPqParams(acceleratedHNSWParams.getCuVSIvfPqParams())
-          .build();
-    }
+    return new CagraIndexParamsFactory().create(acceleratedHNSWParams, rows, dimension);
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -12,7 +12,6 @@ import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CagraIndexParams;
 import com.nvidia.cuvs.CuVSMatrix;
 import com.nvidia.cuvs.RowView;
-import com.nvidia.cuvs.lucene.AcceleratedHNSWParams.Strategy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -486,19 +485,5 @@ public class AcceleratedHNSWUtils {
     }
 
     return quantizedVectors;
-  }
-
-  /**
-   * Get an instance of {@link CagraIndexParams} based on the chosen {@link Strategy}
-   *
-   * @param acceleratedHNSWParams instance of the {@link AcceleratedHNSWParams}
-   * @param rows the number of vectors in the data set
-   * @param dimension the vector dimension
-   *
-   * @return an instance of {@link CagraIndexParams}
-   */
-  public static CagraIndexParams getCagraIndexParams(
-      AcceleratedHNSWParams acceleratedHNSWParams, long rows, long dimension) {
-    return CagraIndexParamsFactory.create(acceleratedHNSWParams, rows, dimension);
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -499,6 +499,6 @@ public class AcceleratedHNSWUtils {
    */
   public static CagraIndexParams getCagraIndexParams(
       AcceleratedHNSWParams acceleratedHNSWParams, long rows, long dimension) {
-    return new CagraIndexParamsFactory().create(acceleratedHNSWParams, rows, dimension);
+    return CagraIndexParamsFactory.create(acceleratedHNSWParams, rows, dimension);
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.nvidia.cuvs.lucene;
+
+import com.nvidia.cuvs.CagraIndexParams;
+import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
+import com.nvidia.cuvs.CagraIndexParams.CodebookGen;
+import com.nvidia.cuvs.CagraIndexParams.CudaDataType;
+import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
+import com.nvidia.cuvs.CuVSIvfPqIndexParams;
+import com.nvidia.cuvs.CuVSIvfPqParams;
+import com.nvidia.cuvs.CuVSIvfPqSearchParams;
+
+public class CagraIndexParamsFactory {
+
+  private static final int ALGO_SWITCH_THRESHOLD = 5_000_000;
+
+  private interface IndexParams {
+    CagraIndexParams get();
+  }
+
+  private class NNDescentParams implements IndexParams {
+
+    private int graphDegree;
+    private int intGraphDegree;
+    private int writerThreads;
+    private int nnDescentNumIterations;
+    private CuvsDistanceType cuvsDistanceType;
+
+    private NNDescentParams(
+        int graphDegree,
+        int intGraphDegree,
+        int writerThreads,
+        int nnDescentNumIterations,
+        CuvsDistanceType cuvsDistanceType) {
+      super();
+      this.graphDegree = graphDegree;
+      this.intGraphDegree = intGraphDegree;
+      this.writerThreads = writerThreads;
+      this.nnDescentNumIterations = nnDescentNumIterations;
+      this.cuvsDistanceType = cuvsDistanceType;
+    }
+
+    @Override
+    public CagraIndexParams get() {
+      return new CagraIndexParams.Builder()
+          .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.NN_DESCENT)
+          .withGraphDegree(graphDegree)
+          .withIntermediateGraphDegree(intGraphDegree)
+          .withNNDescentNumIterations(nnDescentNumIterations)
+          .withNumWriterThreads(writerThreads)
+          .withMetric(cuvsDistanceType)
+          .build();
+    }
+  }
+
+  private class IVFPQIndexParams implements IndexParams {
+
+    private long rows;
+    private long dimension;
+    private int graphDegree;
+    private int intGraphDegree;
+    private int writerThreads;
+
+    private IVFPQIndexParams(
+        long rows, long dimension, int graphDegree, int intGraphDegree, int writerThreads) {
+      super();
+      this.rows = rows;
+      this.dimension = dimension;
+      this.graphDegree = graphDegree;
+      this.intGraphDegree = intGraphDegree;
+      this.writerThreads = writerThreads;
+    }
+
+    @Override
+    public CagraIndexParams get() {
+      return new CagraIndexParams.Builder()
+          .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.IVF_PQ)
+          .withCuVSIvfPqParams(getCuVSIvfPqParams(rows, dimension))
+          .withNumWriterThreads(writerThreads)
+          .withIntermediateGraphDegree(intGraphDegree)
+          .withGraphDegree(graphDegree)
+          .build();
+    }
+
+    private CuVSIvfPqParams getCuVSIvfPqParams(long rows, long dimension) {
+
+      int pqDim;
+      int pqBits;
+
+      if (dimension <= 32) {
+        pqDim = 16;
+        pqBits = 8;
+      } else {
+        pqBits = 4;
+        if (dimension <= 64) {
+          pqDim = 32;
+        } else if (dimension <= 128) {
+          pqDim = 64;
+        } else if (dimension <= 192) {
+          pqDim = 96;
+        } else {
+          pqDim = (int) Math.round(Math.ceil(dimension / 2));
+        }
+      }
+
+      int nLists = (int) Math.max(1, rows / 2000);
+      int kmeansNIters = 10;
+
+      double kMinPointsPerCluster = 32;
+      double minKmeansPrainsetPoints = kMinPointsPerCluster * nLists;
+      double maxKmeansTrainsetFraction = 1.0;
+      double minKmeansTrainsetFraction =
+          Math.min(maxKmeansTrainsetFraction, minKmeansPrainsetPoints / rows);
+      double kmeansTrainsetFraction =
+          Math.clamp(
+              1.0 / Math.sqrt(rows * 1e-5), minKmeansTrainsetFraction, maxKmeansTrainsetFraction);
+
+      CodebookGen codebookKind = CodebookGen.PER_SUBSPACE;
+
+      int nProbes = (int) Math.round(Math.sqrt(nLists) / 20 + 4);
+      // search_params.coarse_search_dtype = CUDA_R_16F;
+      // max_internal_batch_size = 128 * 1024;
+      int refinementRate = 1;
+
+      CuVSIvfPqIndexParams cuVSIvfPqIndexParams =
+          new CuVSIvfPqIndexParams.Builder()
+              .withCodebookKind(codebookKind)
+              .withKmeansNIters(kmeansNIters)
+              .withKmeansTrainsetFraction(kmeansTrainsetFraction)
+              .withNLists(nLists)
+              .withPqBits(pqBits)
+              .withPqDim(pqDim)
+              .build();
+
+      CuVSIvfPqSearchParams cuVSIvfPqSearchParams =
+          new CuVSIvfPqSearchParams.Builder()
+              .withLutDtype(CudaDataType.CUDA_R_16F)
+              .withInternalDistanceDtype(CudaDataType.CUDA_R_16F)
+              .withNProbes(nProbes)
+              .build();
+
+      CuVSIvfPqParams cuVSIvfPqParams =
+          new CuVSIvfPqParams.Builder()
+              .withCuVSIvfPqIndexParams(cuVSIvfPqIndexParams)
+              .withCuVSIvfPqSearchParams(cuVSIvfPqSearchParams)
+              .withRefinementRate(refinementRate)
+              .build();
+
+      return cuVSIvfPqParams;
+    }
+  }
+
+  public CagraIndexParams create(GPUSearchParams params, long rows, long dimension) {
+    if (params.getStrategy().equals(GPUSearchParams.Strategy.HEURISTIC)) {
+      if (rows < ALGO_SWITCH_THRESHOLD) {
+        return new NNDescentParams(
+                params.getGraphdegree(),
+                params.getIntermediateGraphDegree(),
+                params.getWriterThreads(),
+                20,
+                params.getCuvsDistanceType())
+            .get();
+      } else {
+        return new IVFPQIndexParams(
+                rows,
+                dimension,
+                params.getGraphdegree(),
+                params.getIntermediateGraphDegree(),
+                params.getWriterThreads())
+            .get();
+      }
+    } else {
+      return new CagraIndexParams.Builder()
+          .withNumWriterThreads(params.getWriterThreads())
+          .withIntermediateGraphDegree(params.getIntermediateGraphDegree())
+          .withGraphDegree(params.getGraphdegree())
+          .withCagraGraphBuildAlgo(params.getCagraGraphBuildAlgo())
+          .withCuVSIvfPqParams(params.getCuVSIvfPqParams())
+          .build();
+    }
+  }
+
+  public CagraIndexParams create(AcceleratedHNSWParams params, long rows, long dimension) {
+    if (params.getStrategy().equals(AcceleratedHNSWParams.Strategy.HEURISTIC)) {
+      if (rows < ALGO_SWITCH_THRESHOLD) {
+        return new NNDescentParams(
+                params.getGraphdegree(),
+                params.getIntermediateGraphDegree(),
+                params.getWriterThreads(),
+                20,
+                params.getCuvsDistanceType())
+            .get();
+      } else {
+        return new IVFPQIndexParams(
+                rows,
+                dimension,
+                params.getGraphdegree(),
+                params.getIntermediateGraphDegree(),
+                params.getWriterThreads())
+            .get();
+      }
+    } else {
+      return new CagraIndexParams.Builder()
+          .withNumWriterThreads(params.getWriterThreads())
+          .withIntermediateGraphDegree(params.getIntermediateGraphDegree())
+          .withGraphDegree(params.getGraphdegree())
+          .withCagraGraphBuildAlgo(params.getCagraGraphBuildAlgo())
+          .withCuVSIvfPqParams(params.getCuVSIvfPqParams())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
@@ -18,198 +18,160 @@ public class CagraIndexParamsFactory {
 
   private static final int ALGO_SWITCH_THRESHOLD = 5_000_000;
 
-  private interface IndexParams {
-    CagraIndexParams get();
-  }
+  private static CuVSIvfPqParams getCuVSIvfPqParams(long rows, long dimension) {
 
-  private class NNDescentParams implements IndexParams {
+    int pqDim;
+    int pqBits;
 
-    private int graphDegree;
-    private int intGraphDegree;
-    private int writerThreads;
-    private int nnDescentNumIterations;
-    private CuvsDistanceType cuvsDistanceType;
-
-    private NNDescentParams(
-        int graphDegree,
-        int intGraphDegree,
-        int writerThreads,
-        int nnDescentNumIterations,
-        CuvsDistanceType cuvsDistanceType) {
-      super();
-      this.graphDegree = graphDegree;
-      this.intGraphDegree = intGraphDegree;
-      this.writerThreads = writerThreads;
-      this.nnDescentNumIterations = nnDescentNumIterations;
-      this.cuvsDistanceType = cuvsDistanceType;
-    }
-
-    @Override
-    public CagraIndexParams get() {
-      return new CagraIndexParams.Builder()
-          .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.NN_DESCENT)
-          .withGraphDegree(graphDegree)
-          .withIntermediateGraphDegree(intGraphDegree)
-          .withNNDescentNumIterations(nnDescentNumIterations)
-          .withNumWriterThreads(writerThreads)
-          .withMetric(cuvsDistanceType)
-          .build();
-    }
-  }
-
-  private class IVFPQIndexParams implements IndexParams {
-
-    private long rows;
-    private long dimension;
-    private int graphDegree;
-    private int intGraphDegree;
-    private int writerThreads;
-
-    private IVFPQIndexParams(
-        long rows, long dimension, int graphDegree, int intGraphDegree, int writerThreads) {
-      super();
-      this.rows = rows;
-      this.dimension = dimension;
-      this.graphDegree = graphDegree;
-      this.intGraphDegree = intGraphDegree;
-      this.writerThreads = writerThreads;
-    }
-
-    @Override
-    public CagraIndexParams get() {
-      return new CagraIndexParams.Builder()
-          .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.IVF_PQ)
-          .withCuVSIvfPqParams(getCuVSIvfPqParams(rows, dimension))
-          .withNumWriterThreads(writerThreads)
-          .withIntermediateGraphDegree(intGraphDegree)
-          .withGraphDegree(graphDegree)
-          .build();
-    }
-
-    private CuVSIvfPqParams getCuVSIvfPqParams(long rows, long dimension) {
-
-      int pqDim;
-      int pqBits;
-
-      if (dimension <= 32) {
-        pqDim = 16;
-        pqBits = 8;
+    if (dimension <= 32) {
+      pqDim = 16;
+      pqBits = 8;
+    } else {
+      pqBits = 4;
+      if (dimension <= 64) {
+        pqDim = 32;
+      } else if (dimension <= 128) {
+        pqDim = 64;
+      } else if (dimension <= 192) {
+        pqDim = 96;
       } else {
-        pqBits = 4;
-        if (dimension <= 64) {
-          pqDim = 32;
-        } else if (dimension <= 128) {
-          pqDim = 64;
-        } else if (dimension <= 192) {
-          pqDim = 96;
-        } else {
-          pqDim = (int) Math.round(Math.ceil(dimension / 2));
-        }
+        pqDim = (int) roundUpSafe(dimension / 2, 128);
       }
-
-      int nLists = (int) Math.max(1, rows / 2000);
-      int kmeansNIters = 10;
-
-      double kMinPointsPerCluster = 32;
-      double minKmeansPrainsetPoints = kMinPointsPerCluster * nLists;
-      double maxKmeansTrainsetFraction = 1.0;
-      double minKmeansTrainsetFraction =
-          Math.min(maxKmeansTrainsetFraction, minKmeansPrainsetPoints / rows);
-      double kmeansTrainsetFraction =
-          Math.clamp(
-              1.0 / Math.sqrt(rows * 1e-5), minKmeansTrainsetFraction, maxKmeansTrainsetFraction);
-
-      CodebookGen codebookKind = CodebookGen.PER_SUBSPACE;
-
-      int nProbes = (int) Math.round(Math.sqrt(nLists) / 20 + 4);
-      // search_params.coarse_search_dtype = CUDA_R_16F;
-      // max_internal_batch_size = 128 * 1024;
-      int refinementRate = 1;
-
-      CuVSIvfPqIndexParams cuVSIvfPqIndexParams =
-          new CuVSIvfPqIndexParams.Builder()
-              .withCodebookKind(codebookKind)
-              .withKmeansNIters(kmeansNIters)
-              .withKmeansTrainsetFraction(kmeansTrainsetFraction)
-              .withNLists(nLists)
-              .withPqBits(pqBits)
-              .withPqDim(pqDim)
-              .build();
-
-      CuVSIvfPqSearchParams cuVSIvfPqSearchParams =
-          new CuVSIvfPqSearchParams.Builder()
-              .withLutDtype(CudaDataType.CUDA_R_16F)
-              .withInternalDistanceDtype(CudaDataType.CUDA_R_16F)
-              .withNProbes(nProbes)
-              .build();
-
-      CuVSIvfPqParams cuVSIvfPqParams =
-          new CuVSIvfPqParams.Builder()
-              .withCuVSIvfPqIndexParams(cuVSIvfPqIndexParams)
-              .withCuVSIvfPqSearchParams(cuVSIvfPqSearchParams)
-              .withRefinementRate(refinementRate)
-              .build();
-
-      return cuVSIvfPqParams;
     }
+
+    int nLists = (int) Math.max(1, rows / 2000);
+    final int kmeansNIters = 10;
+    final double kMinPointsPerCluster = 32;
+    double minKmeansPrainsetPoints = kMinPointsPerCluster * nLists;
+    final double maxKmeansTrainsetFraction = 1.0;
+    double minKmeansTrainsetFraction =
+        Math.min(maxKmeansTrainsetFraction, minKmeansPrainsetPoints / rows);
+    double kmeansTrainsetFraction =
+        Math.clamp(
+            1.0 / Math.sqrt(rows * 1e-5), minKmeansTrainsetFraction, maxKmeansTrainsetFraction);
+    final CodebookGen codebookKind = CodebookGen.PER_SUBSPACE;
+    int nProbes = (int) Math.round(Math.sqrt(nLists) / 20 + 4);
+    final int refinementRate = 1;
+
+    CuVSIvfPqIndexParams cuVSIvfPqIndexParams =
+        new CuVSIvfPqIndexParams.Builder()
+            .withCodebookKind(codebookKind)
+            .withKmeansNIters(kmeansNIters)
+            .withKmeansTrainsetFraction(kmeansTrainsetFraction)
+            .withNLists(nLists)
+            .withPqBits(pqBits)
+            .withPqDim(pqDim)
+            .withAddDataOnBuild(false)
+            .withConservativeMemoryAllocation(true)
+            .build();
+
+    CuVSIvfPqSearchParams cuVSIvfPqSearchParams =
+        new CuVSIvfPqSearchParams.Builder()
+            .withLutDtype(CudaDataType.CUDA_R_16F)
+            .withInternalDistanceDtype(CudaDataType.CUDA_R_16F)
+            .withNProbes(nProbes)
+            .build();
+
+    CuVSIvfPqParams cuVSIvfPqParams =
+        new CuVSIvfPqParams.Builder()
+            .withCuVSIvfPqIndexParams(cuVSIvfPqIndexParams)
+            .withCuVSIvfPqSearchParams(cuVSIvfPqSearchParams)
+            .withRefinementRate(refinementRate)
+            .build();
+
+    return cuVSIvfPqParams;
   }
 
-  public CagraIndexParams create(GPUSearchParams params, long rows, long dimension) {
-    if (params.getStrategy().equals(GPUSearchParams.Strategy.HEURISTIC)) {
+  private static long roundUpSafe(long numberToRound, long modulus) {
+    long remainder = numberToRound % modulus;
+    if (remainder == 0) {
+      return numberToRound;
+    }
+    long roundedUp = numberToRound - remainder + modulus;
+    return roundedUp;
+  }
+
+  private static CagraIndexParams getNNDescentParams(
+      int graphDegree,
+      int intGraphDegree,
+      int writerThreads,
+      long nnDescentNumIterations,
+      CuvsDistanceType cuvsDistanceType) {
+    return new CagraIndexParams.Builder()
+        .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.NN_DESCENT)
+        .withGraphDegree(graphDegree)
+        .withIntermediateGraphDegree(intGraphDegree)
+        .withNNDescentNumIterations(nnDescentNumIterations)
+        .withNumWriterThreads(writerThreads)
+        .withMetric(cuvsDistanceType)
+        .build();
+  }
+
+  private static CagraIndexParams getIVFPQParams(
+      int graphDegree, int intGraphDegree, int writerThreads, long rows, long dimension) {
+    return new CagraIndexParams.Builder()
+        .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.IVF_PQ)
+        .withCuVSIvfPqParams(getCuVSIvfPqParams(rows, dimension))
+        .withNumWriterThreads(writerThreads)
+        .withIntermediateGraphDegree(intGraphDegree)
+        .withGraphDegree(graphDegree)
+        .build();
+  }
+
+  public static CagraIndexParams create(
+      GPUSearchParams gPUSearchParams, long rows, long dimension) {
+    if (gPUSearchParams.getStrategy().equals(GPUSearchParams.Strategy.HEURISTIC)) {
       if (rows < ALGO_SWITCH_THRESHOLD) {
-        return new NNDescentParams(
-                params.getGraphdegree(),
-                params.getIntermediateGraphDegree(),
-                params.getWriterThreads(),
-                20,
-                params.getCuvsDistanceType())
-            .get();
+        return getNNDescentParams(
+            gPUSearchParams.getGraphdegree(),
+            gPUSearchParams.getIntermediateGraphDegree(),
+            gPUSearchParams.getWriterThreads(),
+            gPUSearchParams.getnNDescentNumIterations(),
+            gPUSearchParams.getCuvsDistanceType());
       } else {
-        return new IVFPQIndexParams(
-                rows,
-                dimension,
-                params.getGraphdegree(),
-                params.getIntermediateGraphDegree(),
-                params.getWriterThreads())
-            .get();
+        return getIVFPQParams(
+            gPUSearchParams.getGraphdegree(),
+            gPUSearchParams.getIntermediateGraphDegree(),
+            gPUSearchParams.getWriterThreads(),
+            rows,
+            dimension);
       }
     } else {
       return new CagraIndexParams.Builder()
-          .withNumWriterThreads(params.getWriterThreads())
-          .withIntermediateGraphDegree(params.getIntermediateGraphDegree())
-          .withGraphDegree(params.getGraphdegree())
-          .withCagraGraphBuildAlgo(params.getCagraGraphBuildAlgo())
-          .withCuVSIvfPqParams(params.getCuVSIvfPqParams())
+          .withNumWriterThreads(gPUSearchParams.getWriterThreads())
+          .withIntermediateGraphDegree(gPUSearchParams.getIntermediateGraphDegree())
+          .withGraphDegree(gPUSearchParams.getGraphdegree())
+          .withCagraGraphBuildAlgo(gPUSearchParams.getCagraGraphBuildAlgo())
+          .withCuVSIvfPqParams(gPUSearchParams.getCuVSIvfPqParams())
           .build();
     }
   }
 
-  public CagraIndexParams create(AcceleratedHNSWParams params, long rows, long dimension) {
-    if (params.getStrategy().equals(AcceleratedHNSWParams.Strategy.HEURISTIC)) {
+  public static CagraIndexParams create(
+      AcceleratedHNSWParams acceleratedHNSWParams, long rows, long dimension) {
+    if (acceleratedHNSWParams.getStrategy().equals(AcceleratedHNSWParams.Strategy.HEURISTIC)) {
       if (rows < ALGO_SWITCH_THRESHOLD) {
-        return new NNDescentParams(
-                params.getGraphdegree(),
-                params.getIntermediateGraphDegree(),
-                params.getWriterThreads(),
-                20,
-                params.getCuvsDistanceType())
-            .get();
+        return getNNDescentParams(
+            acceleratedHNSWParams.getGraphdegree(),
+            acceleratedHNSWParams.getIntermediateGraphDegree(),
+            acceleratedHNSWParams.getWriterThreads(),
+            acceleratedHNSWParams.getnNDescentNumIterations(),
+            acceleratedHNSWParams.getCuvsDistanceType());
       } else {
-        return new IVFPQIndexParams(
-                rows,
-                dimension,
-                params.getGraphdegree(),
-                params.getIntermediateGraphDegree(),
-                params.getWriterThreads())
-            .get();
+        return getIVFPQParams(
+            acceleratedHNSWParams.getGraphdegree(),
+            acceleratedHNSWParams.getIntermediateGraphDegree(),
+            acceleratedHNSWParams.getWriterThreads(),
+            rows,
+            dimension);
       }
     } else {
       return new CagraIndexParams.Builder()
-          .withNumWriterThreads(params.getWriterThreads())
-          .withIntermediateGraphDegree(params.getIntermediateGraphDegree())
-          .withGraphDegree(params.getGraphdegree())
-          .withCagraGraphBuildAlgo(params.getCagraGraphBuildAlgo())
-          .withCuVSIvfPqParams(params.getCuVSIvfPqParams())
+          .withNumWriterThreads(acceleratedHNSWParams.getWriterThreads())
+          .withIntermediateGraphDegree(acceleratedHNSWParams.getIntermediateGraphDegree())
+          .withGraphDegree(acceleratedHNSWParams.getGraphdegree())
+          .withCagraGraphBuildAlgo(acceleratedHNSWParams.getCagraGraphBuildAlgo())
+          .withCuVSIvfPqParams(acceleratedHNSWParams.getCuVSIvfPqParams())
           .build();
     }
   }

--- a/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
@@ -61,7 +61,7 @@ public class CagraIndexParamsFactory {
             .withNLists(nLists)
             .withPqBits(pqBits)
             .withPqDim(pqDim)
-            .withAddDataOnBuild(false)
+            .withAddDataOnBuild(true)
             .withConservativeMemoryAllocation(true)
             .build();
 

--- a/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
@@ -14,10 +14,20 @@ import com.nvidia.cuvs.CuVSIvfPqIndexParams;
 import com.nvidia.cuvs.CuVSIvfPqParams;
 import com.nvidia.cuvs.CuVSIvfPqSearchParams;
 
+/**
+ * A centralized approach to producing instances of {@link CagraIndexParams} based on the chosen strategy
+ */
 public class CagraIndexParamsFactory {
 
   private static final int ALGO_SWITCH_THRESHOLD = 5_000_000;
 
+  /**
+   * Translation of the internal logic found here:
+   * https://github.com/rapidsai/cuvs/blob/main/cpp/include/cuvs/neighbors/ivf_pq.hpp#L3385-L3428
+   *
+   * Ideally we should hook into the internal API but this is currently replicated to avoid complications
+   * in other parts of code base.
+   */
   private static CuVSIvfPqParams getCuVSIvfPqParams(long rows, long dimension) {
 
     int pqDim;
@@ -82,6 +92,10 @@ public class CagraIndexParamsFactory {
     return cuVSIvfPqParams;
   }
 
+  /*
+   * Rough translation from raft's internal utility found here:
+   * https://github.com/rapidsai/raft/blob/main/cpp/include/raft/util/integer_utils.hpp#L47-L56
+   */
   private static long roundUpSafe(long numberToRound, long modulus) {
     long remainder = numberToRound % modulus;
     if (remainder == 0) {
@@ -118,6 +132,14 @@ public class CagraIndexParamsFactory {
         .build();
   }
 
+  /**
+   * Creates an instance of {@link CagraIndexParams} based on the chosen strategy in the {@link GPUSearchParams}.
+   *
+   * @param gPUSearchParams an instance of {@link GPUSearchParams} containing input params incoming via the build and search on the GPU API.
+   * @param rows number of vectors in the data set
+   * @param dimension the dimension of the vectors in the data set
+   * @return an instance of {@link CagraIndexParams}
+   */
   public static CagraIndexParams create(
       GPUSearchParams gPUSearchParams, long rows, long dimension) {
     if (gPUSearchParams.getStrategy().equals(GPUSearchParams.Strategy.HEURISTIC)) {
@@ -147,10 +169,25 @@ public class CagraIndexParamsFactory {
     }
   }
 
+  /*
+   * Ideally there should be just one create method instead of two.
+   * We should do that when both the input parameter classes can be unified in the future.
+   */
+
+  /**
+   * Creates an instance of {@link CagraIndexParams} based on the chosen strategy in the {@link AcceleratedHNSWParams}.
+   *
+   * @param acceleratedHNSWParams an instance of {@link AcceleratedHNSWParams} containing input params incoming via the build and search on the GPU API.
+   * @param rows number of vectors in the data set
+   * @param dimension the dimension of the vectors in the data set
+   * @return an instance of {@link CagraIndexParams}
+   */
   public static CagraIndexParams create(
       AcceleratedHNSWParams acceleratedHNSWParams, long rows, long dimension) {
     if (acceleratedHNSWParams.getStrategy().equals(AcceleratedHNSWParams.Strategy.HEURISTIC)) {
-      if (rows < ALGO_SWITCH_THRESHOLD) {
+      if (rows
+          < ALGO_SWITCH_THRESHOLD) { // TODO: maybe consider making this threshold configurable from
+        // outside later.
         return getNNDescentParams(
             acceleratedHNSWParams.getGraphdegree(),
             acceleratedHNSWParams.getIntermediateGraphDegree(),

--- a/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
@@ -52,7 +52,7 @@ public class CagraIndexParamsFactory {
     int nLists = (int) Math.max(1, rows / 2000);
     final int kmeansNIters = 10;
     final double kMinPointsPerCluster = 32;
-    double minKmeansPrainsetPoints = kMinPointsPerCluster * nLists;
+    double minKmeansTrainsetPoints = kMinPointsPerCluster * nLists;
     final double maxKmeansTrainsetFraction = 1.0;
     double minKmeansTrainsetFraction =
         Math.min(maxKmeansTrainsetFraction, minKmeansPrainsetPoints / rows);

--- a/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CagraIndexParamsFactory.java
@@ -55,7 +55,7 @@ public class CagraIndexParamsFactory {
     double minKmeansTrainsetPoints = kMinPointsPerCluster * nLists;
     final double maxKmeansTrainsetFraction = 1.0;
     double minKmeansTrainsetFraction =
-        Math.min(maxKmeansTrainsetFraction, minKmeansPrainsetPoints / rows);
+        Math.min(maxKmeansTrainsetFraction, minKmeansTrainsetPoints / rows);
     double kmeansTrainsetFraction =
         Math.clamp(
             1.0 / Math.sqrt(rows * 1e-5), minKmeansTrainsetFraction, maxKmeansTrainsetFraction);
@@ -122,13 +122,19 @@ public class CagraIndexParamsFactory {
   }
 
   private static CagraIndexParams getIVFPQParams(
-      int graphDegree, int intGraphDegree, int writerThreads, long rows, long dimension) {
+      int graphDegree,
+      int intGraphDegree,
+      int writerThreads,
+      long rows,
+      long dimension,
+      CuvsDistanceType cuvsDistanceType) {
     return new CagraIndexParams.Builder()
         .withCagraGraphBuildAlgo(CagraGraphBuildAlgo.IVF_PQ)
         .withCuVSIvfPqParams(getCuVSIvfPqParams(rows, dimension))
         .withNumWriterThreads(writerThreads)
         .withIntermediateGraphDegree(intGraphDegree)
         .withGraphDegree(graphDegree)
+        .withMetric(cuvsDistanceType)
         .build();
   }
 
@@ -156,7 +162,8 @@ public class CagraIndexParamsFactory {
             gPUSearchParams.getIntermediateGraphDegree(),
             gPUSearchParams.getWriterThreads(),
             rows,
-            dimension);
+            dimension,
+            gPUSearchParams.getCuvsDistanceType());
       }
     } else {
       return new CagraIndexParams.Builder()
@@ -165,6 +172,7 @@ public class CagraIndexParamsFactory {
           .withGraphDegree(gPUSearchParams.getGraphdegree())
           .withCagraGraphBuildAlgo(gPUSearchParams.getCagraGraphBuildAlgo())
           .withCuVSIvfPqParams(gPUSearchParams.getCuVSIvfPqParams())
+          .withNNDescentNumIterations(gPUSearchParams.getnNDescentNumIterations())
           .build();
     }
   }
@@ -192,7 +200,7 @@ public class CagraIndexParamsFactory {
             acceleratedHNSWParams.getGraphdegree(),
             acceleratedHNSWParams.getIntermediateGraphDegree(),
             acceleratedHNSWParams.getWriterThreads(),
-            acceleratedHNSWParams.getnNDescentNumIterations(),
+            acceleratedHNSWParams.getNNDescentNumIterations(),
             acceleratedHNSWParams.getCuvsDistanceType());
       } else {
         return getIVFPQParams(
@@ -200,7 +208,8 @@ public class CagraIndexParamsFactory {
             acceleratedHNSWParams.getIntermediateGraphDegree(),
             acceleratedHNSWParams.getWriterThreads(),
             rows,
-            dimension);
+            dimension,
+            acceleratedHNSWParams.getCuvsDistanceType());
       }
     } else {
       return new CagraIndexParams.Builder()
@@ -209,6 +218,7 @@ public class CagraIndexParamsFactory {
           .withGraphDegree(acceleratedHNSWParams.getGraphdegree())
           .withCagraGraphBuildAlgo(acceleratedHNSWParams.getCagraGraphBuildAlgo())
           .withCuVSIvfPqParams(acceleratedHNSWParams.getCuVSIvfPqParams())
+          .withNNDescentNumIterations(acceleratedHNSWParams.getNNDescentNumIterations())
           .build();
     }
   }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -242,7 +242,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    */
   private void writeCagraIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
     CagraIndexParams params =
-        new CagraIndexParamsFactory().create(gpuSearchParams, dataset.size(), dataset.columns());
+        CagraIndexParamsFactory.create(gpuSearchParams, dataset.size(), dataset.columns());
     CagraIndex index =
         CagraIndex.newBuilder(getCuVSResourcesInstance())
             .withDataset(dataset)

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -21,6 +21,7 @@ import com.nvidia.cuvs.BruteForceIndexParams;
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CagraIndexParams;
 import com.nvidia.cuvs.CuVSMatrix;
+import com.nvidia.cuvs.lucene.GPUSearchParams.Strategy;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -241,14 +242,26 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    * @throws Throwable
    */
   private void writeCagraIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
-    CagraIndexParams params =
-        new CagraIndexParams.Builder()
-            .withNumWriterThreads(gpuSearchParams.getWriterThreads())
-            .withIntermediateGraphDegree(gpuSearchParams.getIntermediateGraphDegree())
-            .withGraphDegree(gpuSearchParams.getGraphdegree())
-            .withCagraGraphBuildAlgo(gpuSearchParams.getCagraGraphBuildAlgo())
-            .withCuVSIvfPqParams(gpuSearchParams.getCuVSIvfPqParams())
-            .build();
+    CagraIndexParams params;
+    if (gpuSearchParams.getStrategy().equals(Strategy.HEURISTIC)) {
+      params =
+          CagraIndexParams.fromHnswParams(
+              dataset.size(),
+              dataset.columns(),
+              gpuSearchParams.getM(),
+              gpuSearchParams.getEfConstruction(),
+              gpuSearchParams.getHeuristicType(),
+              gpuSearchParams.getCuvsDistanceType());
+    } else {
+      params =
+          new CagraIndexParams.Builder()
+              .withNumWriterThreads(gpuSearchParams.getWriterThreads())
+              .withIntermediateGraphDegree(gpuSearchParams.getIntermediateGraphDegree())
+              .withGraphDegree(gpuSearchParams.getGraphdegree())
+              .withCagraGraphBuildAlgo(gpuSearchParams.getCagraGraphBuildAlgo())
+              .withCuVSIvfPqParams(gpuSearchParams.getCuVSIvfPqParams())
+              .build();
+    }
     CagraIndex index =
         CagraIndex.newBuilder(getCuVSResourcesInstance())
             .withDataset(dataset)

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -21,7 +21,6 @@ import com.nvidia.cuvs.BruteForceIndexParams;
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CagraIndexParams;
 import com.nvidia.cuvs.CuVSMatrix;
-import com.nvidia.cuvs.lucene.GPUSearchParams.Strategy;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -242,26 +241,8 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
    * @throws Throwable
    */
   private void writeCagraIndex(OutputStream os, CuVSMatrix dataset) throws Throwable {
-    CagraIndexParams params;
-    if (gpuSearchParams.getStrategy().equals(Strategy.HEURISTIC)) {
-      params =
-          CagraIndexParams.fromHnswParams(
-              dataset.size(),
-              dataset.columns(),
-              gpuSearchParams.getM(),
-              gpuSearchParams.getEfConstruction(),
-              gpuSearchParams.getHeuristicType(),
-              gpuSearchParams.getCuvsDistanceType());
-    } else {
-      params =
-          new CagraIndexParams.Builder()
-              .withNumWriterThreads(gpuSearchParams.getWriterThreads())
-              .withIntermediateGraphDegree(gpuSearchParams.getIntermediateGraphDegree())
-              .withGraphDegree(gpuSearchParams.getGraphdegree())
-              .withCagraGraphBuildAlgo(gpuSearchParams.getCagraGraphBuildAlgo())
-              .withCuVSIvfPqParams(gpuSearchParams.getCuVSIvfPqParams())
-              .build();
-    }
+    CagraIndexParams params =
+        new CagraIndexParamsFactory().create(gpuSearchParams, dataset.size(), dataset.columns());
     CagraIndex index =
         CagraIndex.newBuilder(getCuVSResourcesInstance())
             .withDataset(dataset)

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -9,6 +9,7 @@ import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
 import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
 import com.nvidia.cuvs.CagraIndexParams.HnswHeuristicType;
 import com.nvidia.cuvs.CuVSIvfPqParams;
+import com.nvidia.cuvs.lucene.AcceleratedHNSWParams.Builder;
 import com.nvidia.cuvs.lucene.CuVS2510GPUVectorsWriter.IndexType;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -41,10 +42,8 @@ public class GPUSearchParams {
   public static final int MAX_INT_GRAPH_DEG = 512;
   public static final int MIN_GRAPH_DEG = 1;
   public static final int MAX_GRAPH_DEG = 512;
-  public static final int MIN_M = 1;
-  public static final int MAX_M = 1024;
-  public static final int MIN_EF_CONSTRUCTION = 1;
-  public static final int MAX_EF_CONSTRUCTION = 1024;
+  public static final long MIN_NN_DESCENT_NUM_ITERATIONS = 1;
+  public static final long MAX_NN_DESCENT_NUM_ITERATIONS = 100;
 
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
   public static final int DEFAULT_GRAPH_DEGREE = 64;
@@ -58,6 +57,7 @@ public class GPUSearchParams {
   public static final HnswHeuristicType DEFAULT_HEURISTIC_TYPE =
       HnswHeuristicType.SAME_GRAPH_FOOTPRINT;
   public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
+  public static final long DEFAULT_NN_DESCENT_NUM_ITERATIONS = 20;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
       () -> {
@@ -72,6 +72,7 @@ public class GPUSearchParams {
   private final CuVSIvfPqParams cuVSIvfPqParams;
   private final Strategy strategy;
   private final CuvsDistanceType cuvsDistanceType;
+  private final long nNDescentNumIterations;
 
   /**
    * Constructs an instance of {@link GPUSearchParams} with specific parameter values.
@@ -87,6 +88,7 @@ public class GPUSearchParams {
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
    * @param heuristicType the heuristic type. The default option is SAME_GRAPH_FOOTPRINT.
    * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
+   * @param nNDescentNumIterations the number of Iterations to run if building with NN_DESCENT.
    */
   private GPUSearchParams(
       int writerThreads,
@@ -96,7 +98,8 @@ public class GPUSearchParams {
       IndexType indexType,
       CuVSIvfPqParams cuVSIvfPqParams,
       Strategy strategy,
-      CuvsDistanceType cuvsDistanceType) {
+      CuvsDistanceType cuvsDistanceType,
+      long nNDescentNumIterations) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
@@ -106,6 +109,7 @@ public class GPUSearchParams {
     this.cuVSIvfPqParams = cuVSIvfPqParams;
     this.strategy = strategy;
     this.cuvsDistanceType = cuvsDistanceType;
+    this.nNDescentNumIterations = nNDescentNumIterations;
   }
 
   /**
@@ -184,6 +188,15 @@ public class GPUSearchParams {
     return cuvsDistanceType;
   }
 
+  /**
+   * get the number of Iterations to run if building with NN_DESCENT
+   *
+   * @return the number of iterations for NN_DESCENT
+   */
+  public long getnNDescentNumIterations() {
+    return nNDescentNumIterations;
+  }
+
   @Override
   public String toString() {
     return "GPUSearchParams [writerThreads="
@@ -202,6 +215,8 @@ public class GPUSearchParams {
         + strategy
         + ", cuvsDistanceType="
         + cuvsDistanceType
+        + ", nNDescentNumIterations="
+        + nNDescentNumIterations
         + "]";
   }
 
@@ -218,6 +233,7 @@ public class GPUSearchParams {
     private CuVSIvfPqParams cuVSIvfPqParams = null;
     private Strategy strategy = DEFAULT_STRATEGY;
     private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
+    private long nNDescentNumIterations = DEFAULT_NN_DESCENT_NUM_ITERATIONS;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -322,6 +338,20 @@ public class GPUSearchParams {
     }
 
     /**
+     * Set the number of Iterations to run if building with NN_DESCENT
+     *
+     * Valid range - Minimum: {@value MIN_NN_DESCENT_NUM_ITERATIONS}, Maximum: {@value MAX_NN_DESCENT_NUM_ITERATIONS}
+     * Default value - {@value DEFAULT_NN_DESCENT_NUM_ITERATIONS}
+     *
+     * @param nNDescentNumIterations number of merge workers to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withNNDescentNumIterations(int nNDescentNumIterations) {
+      this.nNDescentNumIterations = nNDescentNumIterations;
+      return this;
+    }
+
+    /**
      * Validates the input parameters.
      *
      * @throws IllegalArgumentException
@@ -364,6 +394,15 @@ public class GPUSearchParams {
       if (Objects.isNull(cuvsDistanceType)) {
         throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
       }
+      if (nNDescentNumIterations < MIN_NN_DESCENT_NUM_ITERATIONS
+          || nNDescentNumIterations > MAX_NN_DESCENT_NUM_ITERATIONS) {
+        throw new IllegalArgumentException(
+            "nNDescentNumIterations not in valid range. Valid range: ["
+                + MIN_NN_DESCENT_NUM_ITERATIONS
+                + ", "
+                + MAX_NN_DESCENT_NUM_ITERATIONS
+                + "]");
+      }
     }
 
     /**
@@ -384,7 +423,8 @@ public class GPUSearchParams {
           indexType,
           cuVSIvfPqParams,
           strategy,
-          cuvsDistanceType);
+          cuvsDistanceType,
+          nNDescentNumIterations);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -6,12 +6,19 @@
 package com.nvidia.cuvs.lucene;
 
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
+import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
+import com.nvidia.cuvs.CagraIndexParams.HnswHeuristicType;
 import com.nvidia.cuvs.CuVSIvfPqParams;
 import com.nvidia.cuvs.lucene.CuVS2510GPUVectorsWriter.IndexType;
 import java.util.Objects;
 import java.util.function.Supplier;
 
 public class GPUSearchParams {
+
+  public static enum Strategy {
+    HEURISTIC,
+    CUSTOM
+  }
 
   /*
    * TODO: Update boundaries for all parameters when a consensus is reached.
@@ -23,6 +30,10 @@ public class GPUSearchParams {
   public static final int MAX_INT_GRAPH_DEG = 512;
   public static final int MIN_GRAPH_DEG = 1;
   public static final int MAX_GRAPH_DEG = 512;
+  public static final int MIN_M = 1;
+  public static final int MAX_M = 1024;
+  public static final int MIN_EF_CONSTRUCTION = 1;
+  public static final int MAX_EF_CONSTRUCTION = 1024;
 
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
   public static final int DEFAULT_GRAPH_DEGREE = 64;
@@ -30,6 +41,12 @@ public class GPUSearchParams {
       CagraGraphBuildAlgo.NN_DESCENT;
   public static final IndexType DEFAULT_INDEX_TYPE = IndexType.CAGRA;
   public static final int DEFAULT_WRITER_THREADS = 1;
+  public static final int DEFAULT_M = 16;
+  public static final int DEFAULT_EF_CONSTRUCTION = 16;
+  public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
+  public static final HnswHeuristicType DEFAULT_HEURISTIC_TYPE =
+      HnswHeuristicType.SAME_GRAPH_FOOTPRINT;
+  public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
       () -> {
@@ -42,6 +59,11 @@ public class GPUSearchParams {
   private final CagraGraphBuildAlgo cagraGraphBuildAlgo;
   private final IndexType indexType;
   private final CuVSIvfPqParams cuVSIvfPqParams;
+  private final int m;
+  private final int efConstruction;
+  private final Strategy strategy;
+  private final HnswHeuristicType heuristicType;
+  private final CuvsDistanceType cuvsDistanceType;
 
   /**
    * Constructs an instance of {@link GPUSearchParams} with specific parameter values.
@@ -52,6 +74,11 @@ public class GPUSearchParams {
    * @param cagraGraphBuildAlgo The CAGRA build algorithm to use.
    * @param indexType The type of index to build - CAGRA, BRUTEFORCE, or both.
    * @param cuVSIvfPqParams An instance of CuVSIvfPqParams containing IVF_PQ specific parameters.
+   * @param m defines The maximum number of bi-directional links (edges) per node.
+   * @param efConstruction Determines the size of the dynamic candidate list during graph construction.
+   * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
+   * @param heuristicType
+   * @param cuvsDistanceType
    */
   private GPUSearchParams(
       int writerThreads,
@@ -59,7 +86,12 @@ public class GPUSearchParams {
       int graphdegree,
       CagraGraphBuildAlgo cagraGraphBuildAlgo,
       IndexType indexType,
-      CuVSIvfPqParams cuVSIvfPqParams) {
+      CuVSIvfPqParams cuVSIvfPqParams,
+      int m,
+      int efConstruction,
+      Strategy strategy,
+      HnswHeuristicType heuristicType,
+      CuvsDistanceType cuvsDistanceType) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
@@ -67,6 +99,11 @@ public class GPUSearchParams {
     this.cagraGraphBuildAlgo = cagraGraphBuildAlgo;
     this.indexType = indexType;
     this.cuVSIvfPqParams = cuVSIvfPqParams;
+    this.m = m;
+    this.efConstruction = efConstruction;
+    this.strategy = strategy;
+    this.heuristicType = heuristicType;
+    this.cuvsDistanceType = cuvsDistanceType;
   }
 
   /**
@@ -123,6 +160,54 @@ public class GPUSearchParams {
     return cuVSIvfPqParams;
   }
 
+  /**
+   * Get the value of m - defines the maximum number of bi-directional links (edges) per node
+   *
+   * @return the value of m
+   */
+  public int getM() {
+    return m;
+  }
+
+  /**
+   * Get the value of efConstruction - determines the size of the dynamic candidate list during graph construction
+   *
+   * @return the value of efConstruction
+   */
+  public int getEfConstruction() {
+    return efConstruction;
+  }
+
+  /**
+   * Get the chosen strategy:
+   *
+   * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
+   * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+   *
+   * @return get the chosen {@link Strategy}
+   */
+  public Strategy getStrategy() {
+    return strategy;
+  }
+
+  /**
+   * Get the heuristic type
+   *
+   * @return the heuristic type
+   */
+  public HnswHeuristicType getHeuristicType() {
+    return heuristicType;
+  }
+
+  /**
+   * Get the cuvs distance type
+   *
+   * @return the distance type
+   */
+  public CuvsDistanceType getCuvsDistanceType() {
+    return cuvsDistanceType;
+  }
+
   @Override
   public String toString() {
     return "GPUSearchParams [writerThreads="
@@ -135,6 +220,18 @@ public class GPUSearchParams {
         + cagraGraphBuildAlgo
         + ", indexType="
         + indexType
+        + ", cuVSIvfPqParams="
+        + cuVSIvfPqParams
+        + ", m="
+        + m
+        + ", efConstruction="
+        + efConstruction
+        + ", strategy="
+        + strategy
+        + ", heuristicType="
+        + heuristicType
+        + ", cuvsDistanceType="
+        + cuvsDistanceType
         + "]";
   }
 
@@ -149,6 +246,11 @@ public class GPUSearchParams {
     private CagraGraphBuildAlgo cagraGraphBuildAlgo = DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
     private IndexType indexType = DEFAULT_INDEX_TYPE;
     private CuVSIvfPqParams cuVSIvfPqParams = null;
+    private int m = DEFAULT_M;
+    private int efConstruction = DEFAULT_EF_CONSTRUCTION;
+    private Strategy strategy = DEFAULT_STRATEGY;
+    private HnswHeuristicType heuristicType = DEFAULT_HEURISTIC_TYPE;
+    private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -225,6 +327,64 @@ public class GPUSearchParams {
     }
 
     /**
+     * Set the value of m - defines the maximum number of bi-directional links (edges) per node
+     *
+     * @param m, the value to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withM(int m) {
+      this.m = m;
+      return this;
+    }
+
+    /**
+     * Set the value of efConstruction - determines the size of the dynamic candidate list during graph construction
+     *
+     * @param efConstruction, the value to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withEfConstruction(int efConstruction) {
+      this.efConstruction = efConstruction;
+      return this;
+    }
+
+    /**
+     * Set the chosen strategy:
+     *
+     * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
+     * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+     *
+     * @param strategy, the strategy to choose
+     * @return instance of {@link Builder}
+     */
+    public Builder withStrategy(Strategy strategy) {
+      this.strategy = strategy;
+      return this;
+    }
+
+    /**
+     * Set the HnswHeuristicType
+     *
+     * @param the HnswHeuristicType to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withHeuristicType(HnswHeuristicType heuristicType) {
+      this.heuristicType = heuristicType;
+      return this;
+    }
+
+    /**
+     * Set the CuvsDistanceType
+     *
+     * @param the CuvsDistanceType to set
+     * @return instance of {@link Builder}
+     */
+    public Builder withCuvsDistanceType(CuvsDistanceType cuvsDistanceType) {
+      this.cuvsDistanceType = cuvsDistanceType;
+      return this;
+    }
+
+    /**
      * Validates the input parameters.
      *
      * @throws IllegalArgumentException
@@ -261,6 +421,27 @@ public class GPUSearchParams {
       if (Objects.isNull(indexType)) {
         throw new IllegalArgumentException("indexType cannot be null.");
       }
+      if (m < MIN_M || m > MAX_M) {
+        throw new IllegalArgumentException(
+            "m not in valid range. Valid range: [" + MIN_M + ", " + MAX_M + "]");
+      }
+      if (efConstruction < MIN_EF_CONSTRUCTION || efConstruction > MAX_EF_CONSTRUCTION) {
+        throw new IllegalArgumentException(
+            "efConstruction not in valid range. Valid range: ["
+                + MIN_EF_CONSTRUCTION
+                + ", "
+                + MAX_EF_CONSTRUCTION
+                + "]");
+      }
+      if (Objects.isNull(strategy)) {
+        throw new IllegalArgumentException("strategy cannot be null.");
+      }
+      if (Objects.isNull(heuristicType)) {
+        throw new IllegalArgumentException("heuristicType cannot be null.");
+      }
+      if (Objects.isNull(cuvsDistanceType)) {
+        throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
+      }
     }
 
     /**
@@ -279,7 +460,12 @@ public class GPUSearchParams {
           graphdegree,
           cagraGraphBuildAlgo,
           indexType,
-          cuVSIvfPqParams);
+          cuVSIvfPqParams,
+          m,
+          efConstruction,
+          strategy,
+          heuristicType,
+          cuvsDistanceType);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -16,7 +16,35 @@ import java.util.function.Supplier;
 public class GPUSearchParams {
 
   public static enum Strategy {
+    /*
+     * This strategy allows for automatic selection of the underlining build algorithm for CAGRA.
+     * As per the currently chosen threshold we choose NN_DESCENT under 1M vectors.
+     * For 1M vectors, we switch to IVF_PQ algorithm. Also for both algorithms the input parameters
+     * are heuristically assessed internally in the cuvs layer.
+     *
+     * When using this strategy only the following parameters are effective and can be overridden:
+     * - m
+     * - efConstruction
+     * - heuristicType
+     * - cuvsDistanceType
+     * - writerThreads
+     *
+     * This is the default and the recommended strategy.
+     */
     HEURISTIC,
+    /*
+     * This is an option when the end-user would want to use custom parameter values.
+     *
+     * When using this strategy only the following parameters are effective and can be overridden:
+     * - intermediateGraphDegree
+     * - graphdegree
+     * - cagraGraphBuildAlgo
+     * - indexType
+     * - cuVSIvfPqParams
+     * - writerThreads
+     *
+     * This strategy should only be used under expert guidance.
+     */
     CUSTOM
   }
 
@@ -77,8 +105,8 @@ public class GPUSearchParams {
    * @param m defines The maximum number of bi-directional links (edges) per node.
    * @param efConstruction Determines the size of the dynamic candidate list during graph construction.
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
-   * @param heuristicType
-   * @param cuvsDistanceType
+   * @param heuristicType the heuristic type. The default option is SAME_GRAPH_FOOTPRINT.
+   * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
    */
   private GPUSearchParams(
       int writerThreads,
@@ -363,9 +391,9 @@ public class GPUSearchParams {
     }
 
     /**
-     * Set the HnswHeuristicType
+     * Set the heuristic type
      *
-     * @param the HnswHeuristicType to set
+     * @param heuristicType the HnswHeuristicType to set
      * @return instance of {@link Builder}
      */
     public Builder withHeuristicType(HnswHeuristicType heuristicType) {
@@ -376,7 +404,7 @@ public class GPUSearchParams {
     /**
      * Set the CuvsDistanceType
      *
-     * @param the CuvsDistanceType to set
+     * @param cuvsDistanceType the CuvsDistanceType to set
      * @return instance of {@link Builder}
      */
     public Builder withCuvsDistanceType(CuvsDistanceType cuvsDistanceType) {

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -17,32 +17,15 @@ public class GPUSearchParams {
 
   public static enum Strategy {
     /*
-     * This strategy allows for automatic selection of the underlining build algorithm for CAGRA.
-     * As per the currently chosen threshold we choose NN_DESCENT under 1M vectors.
-     * For 1M vectors, we switch to IVF_PQ algorithm. Also for both algorithms the input parameters
-     * are heuristically assessed internally in the cuvs layer.
-     *
-     * When using this strategy only the following parameters are effective and can be overridden:
-     * - m
-     * - efConstruction
-     * - heuristicType
-     * - cuvsDistanceType
-     * - writerThreads
+     * This strategy allows for automatic selection of the underlining CAGRA build algorithm.
+     * With this strategy we use NN_DESCENT for data set less then 5M vectors else we use IVF_PQ.
+     * Indexing parameters, especially for IVF_PQ, are heuristically identified automatically.
      *
      * This is the default and the recommended strategy.
      */
     HEURISTIC,
     /*
      * This is an option when the end-user would want to use custom parameter values.
-     *
-     * When using this strategy only the following parameters are effective and can be overridden:
-     * - intermediateGraphDegree
-     * - graphdegree
-     * - cagraGraphBuildAlgo
-     * - indexType
-     * - cuVSIvfPqParams
-     * - writerThreads
-     *
      * This strategy should only be used under expert guidance.
      */
     CUSTOM
@@ -87,10 +70,7 @@ public class GPUSearchParams {
   private final CagraGraphBuildAlgo cagraGraphBuildAlgo;
   private final IndexType indexType;
   private final CuVSIvfPqParams cuVSIvfPqParams;
-  private final int m;
-  private final int efConstruction;
   private final Strategy strategy;
-  private final HnswHeuristicType heuristicType;
   private final CuvsDistanceType cuvsDistanceType;
 
   /**
@@ -115,10 +95,7 @@ public class GPUSearchParams {
       CagraGraphBuildAlgo cagraGraphBuildAlgo,
       IndexType indexType,
       CuVSIvfPqParams cuVSIvfPqParams,
-      int m,
-      int efConstruction,
       Strategy strategy,
-      HnswHeuristicType heuristicType,
       CuvsDistanceType cuvsDistanceType) {
     super();
     this.writerThreads = writerThreads;
@@ -127,10 +104,7 @@ public class GPUSearchParams {
     this.cagraGraphBuildAlgo = cagraGraphBuildAlgo;
     this.indexType = indexType;
     this.cuVSIvfPqParams = cuVSIvfPqParams;
-    this.m = m;
-    this.efConstruction = efConstruction;
     this.strategy = strategy;
-    this.heuristicType = heuristicType;
     this.cuvsDistanceType = cuvsDistanceType;
   }
 
@@ -189,27 +163,6 @@ public class GPUSearchParams {
   }
 
   /**
-   * Get the value of m - defines the maximum number of bi-directional links (edges) per node
-   *
-   * @return the value of m
-   */
-  public int getM() {
-    return m;
-  }
-
-  /**
-   * Get the value of efConstruction - determines the size of the dynamic candidate list during graph construction
-   *
-   * Valid range - Minimum: {@value MIN_EF_CONSTRUCTION}, Maximum: {@value MAX_EF_CONSTRUCTION}
-   * Default value - {@value DEFAULT_EF_CONSTRUCTION}
-   *
-   * @return the value of efConstruction
-   */
-  public int getEfConstruction() {
-    return efConstruction;
-  }
-
-  /**
    * Get the chosen strategy:
    *
    * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
@@ -220,15 +173,6 @@ public class GPUSearchParams {
    */
   public Strategy getStrategy() {
     return strategy;
-  }
-
-  /**
-   * Get the heuristic type
-   *
-   * @return the heuristic type
-   */
-  public HnswHeuristicType getHeuristicType() {
-    return heuristicType;
   }
 
   /**
@@ -254,14 +198,8 @@ public class GPUSearchParams {
         + indexType
         + ", cuVSIvfPqParams="
         + cuVSIvfPqParams
-        + ", m="
-        + m
-        + ", efConstruction="
-        + efConstruction
         + ", strategy="
         + strategy
-        + ", heuristicType="
-        + heuristicType
         + ", cuvsDistanceType="
         + cuvsDistanceType
         + "]";
@@ -278,10 +216,7 @@ public class GPUSearchParams {
     private CagraGraphBuildAlgo cagraGraphBuildAlgo = DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
     private IndexType indexType = DEFAULT_INDEX_TYPE;
     private CuVSIvfPqParams cuVSIvfPqParams = null;
-    private int m = DEFAULT_M;
-    private int efConstruction = DEFAULT_EF_CONSTRUCTION;
     private Strategy strategy = DEFAULT_STRATEGY;
-    private HnswHeuristicType heuristicType = DEFAULT_HEURISTIC_TYPE;
     private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
 
     /**
@@ -359,34 +294,6 @@ public class GPUSearchParams {
     }
 
     /**
-     * Set the value of m - defines the maximum number of bi-directional links (edges) per node
-     *
-     * Valid range - Minimum: {@value MIN_M}, Maximum: {@value MAX_M}
-     * Default value - {@value DEFAULT_M}
-     *
-     * @param m, the value to set
-     * @return instance of {@link Builder}
-     */
-    public Builder withM(int m) {
-      this.m = m;
-      return this;
-    }
-
-    /**
-     * Set the value of efConstruction - determines the size of the dynamic candidate list during graph construction
-     *
-     * Valid range - Minimum: {@value MIN_EF_CONSTRUCTION}, Maximum: {@value MAX_EF_CONSTRUCTION}
-     * Default value - {@value DEFAULT_EF_CONSTRUCTION}
-     *
-     * @param efConstruction, the value to set
-     * @return instance of {@link Builder}
-     */
-    public Builder withEfConstruction(int efConstruction) {
-      this.efConstruction = efConstruction;
-      return this;
-    }
-
-    /**
      * Set the chosen strategy:
      *
      * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
@@ -400,17 +307,6 @@ public class GPUSearchParams {
      */
     public Builder withStrategy(Strategy strategy) {
       this.strategy = strategy;
-      return this;
-    }
-
-    /**
-     * Set the heuristic type
-     *
-     * @param heuristicType the HnswHeuristicType to set
-     * @return instance of {@link Builder}
-     */
-    public Builder withHeuristicType(HnswHeuristicType heuristicType) {
-      this.heuristicType = heuristicType;
       return this;
     }
 
@@ -462,23 +358,8 @@ public class GPUSearchParams {
       if (Objects.isNull(indexType)) {
         throw new IllegalArgumentException("indexType cannot be null.");
       }
-      if (m < MIN_M || m > MAX_M) {
-        throw new IllegalArgumentException(
-            "m not in valid range. Valid range: [" + MIN_M + ", " + MAX_M + "]");
-      }
-      if (efConstruction < MIN_EF_CONSTRUCTION || efConstruction > MAX_EF_CONSTRUCTION) {
-        throw new IllegalArgumentException(
-            "efConstruction not in valid range. Valid range: ["
-                + MIN_EF_CONSTRUCTION
-                + ", "
-                + MAX_EF_CONSTRUCTION
-                + "]");
-      }
       if (Objects.isNull(strategy)) {
         throw new IllegalArgumentException("strategy cannot be null.");
-      }
-      if (Objects.isNull(heuristicType)) {
-        throw new IllegalArgumentException("heuristicType cannot be null.");
       }
       if (Objects.isNull(cuvsDistanceType)) {
         throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
@@ -502,10 +383,7 @@ public class GPUSearchParams {
           cagraGraphBuildAlgo,
           indexType,
           cuVSIvfPqParams,
-          m,
-          efConstruction,
           strategy,
-          heuristicType,
           cuvsDistanceType);
     }
   }

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -68,7 +68,7 @@ public class GPUSearchParams {
   public static final CagraGraphBuildAlgo DEFAULT_CAGRA_GRAPH_BUILD_ALGO =
       CagraGraphBuildAlgo.NN_DESCENT;
   public static final IndexType DEFAULT_INDEX_TYPE = IndexType.CAGRA;
-  public static final int DEFAULT_WRITER_THREADS = 1;
+  public static final int DEFAULT_WRITER_THREADS = 32;
   public static final int DEFAULT_M = 16;
   public static final int DEFAULT_EF_CONSTRUCTION = 16;
   public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
@@ -200,6 +200,9 @@ public class GPUSearchParams {
   /**
    * Get the value of efConstruction - determines the size of the dynamic candidate list during graph construction
    *
+   * Valid range - Minimum: {@value MIN_EF_CONSTRUCTION}, Maximum: {@value MAX_EF_CONSTRUCTION}
+   * Default value - {@value DEFAULT_EF_CONSTRUCTION}
+   *
    * @return the value of efConstruction
    */
   public int getEfConstruction() {
@@ -211,6 +214,7 @@ public class GPUSearchParams {
    *
    * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
    * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+   *
    *
    * @return get the chosen {@link Strategy}
    */
@@ -283,7 +287,7 @@ public class GPUSearchParams {
     /**
      * Set the number of cuVS writer threads while building the index
      * Valid range - Minimum: {@value MIN_WRITER_THREADS}, Maximum: {@value MAX_WRITER_THREADS}
-     * Default value - 64
+     * Default value - {@value DEFAULT_WRITER_THREADS}
      *
      * @param writerThreads the number of cuVS writer threads
      * @return instance of {@link Builder}
@@ -296,7 +300,7 @@ public class GPUSearchParams {
     /**
      * Set the intermediate graph degree to use while building CAGRA index
      * Valid range - Minimum: {@value MIN_INT_GRAPH_DEG}, Maximum: {@value MAX_INT_GRAPH_DEG}
-     * Default value - 128
+     * Default value - {@value DEFAULT_INT_GRAPH_DEGREE}
      *
      * @param intermediateGraphDegree the intermediate graph degree parameter
      * @return instance of {@link Builder}
@@ -309,7 +313,7 @@ public class GPUSearchParams {
     /**
      * Set the graph degree to use while building CAGRA index
      * Valid range - Minimum: {@value MIN_GRAPH_DEG}, Maximum: {@value MAX_GRAPH_DEG}
-     * Default value - 64
+     * Default value - {@value DEFAULT_GRAPH_DEGREE}
      *
      * @param graphDegree the graph degree parameter
      * @return instance of {@link Builder}
@@ -357,6 +361,9 @@ public class GPUSearchParams {
     /**
      * Set the value of m - defines the maximum number of bi-directional links (edges) per node
      *
+     * Valid range - Minimum: {@value MIN_M}, Maximum: {@value MAX_M}
+     * Default value - {@value DEFAULT_M}
+     *
      * @param m, the value to set
      * @return instance of {@link Builder}
      */
@@ -367,6 +374,9 @@ public class GPUSearchParams {
 
     /**
      * Set the value of efConstruction - determines the size of the dynamic candidate list during graph construction
+     *
+     * Valid range - Minimum: {@value MIN_EF_CONSTRUCTION}, Maximum: {@value MAX_EF_CONSTRUCTION}
+     * Default value - {@value DEFAULT_EF_CONSTRUCTION}
      *
      * @param efConstruction, the value to set
      * @return instance of {@link Builder}
@@ -381,6 +391,9 @@ public class GPUSearchParams {
      *
      * When HEURISTIC [Default] is chosen, the CAGRA build algorithm and its indexing parameters are automatically chosen based on the size of the data set
      * When CUSTOM is chosen, the build algorithm and its parameters (either defaults or overridden values with the use of With* methods) is used internally
+     *
+     * Valid options - HEURISTIC, CUSTOM
+     * Default value - HEURISTIC
      *
      * @param strategy, the strategy to choose
      * @return instance of {@link Builder}

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUSearchParams.java
@@ -7,9 +7,7 @@ package com.nvidia.cuvs.lucene;
 
 import com.nvidia.cuvs.CagraIndexParams.CagraGraphBuildAlgo;
 import com.nvidia.cuvs.CagraIndexParams.CuvsDistanceType;
-import com.nvidia.cuvs.CagraIndexParams.HnswHeuristicType;
 import com.nvidia.cuvs.CuVSIvfPqParams;
-import com.nvidia.cuvs.lucene.AcceleratedHNSWParams.Builder;
 import com.nvidia.cuvs.lucene.CuVS2510GPUVectorsWriter.IndexType;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -42,8 +40,8 @@ public class GPUSearchParams {
   public static final int MAX_INT_GRAPH_DEG = 512;
   public static final int MIN_GRAPH_DEG = 1;
   public static final int MAX_GRAPH_DEG = 512;
-  public static final long MIN_NN_DESCENT_NUM_ITERATIONS = 1;
-  public static final long MAX_NN_DESCENT_NUM_ITERATIONS = 100;
+  public static final int MIN_NN_DESCENT_NUM_ITERATIONS = 1;
+  public static final int MAX_NN_DESCENT_NUM_ITERATIONS = 100;
 
   public static final int DEFAULT_INT_GRAPH_DEGREE = 128;
   public static final int DEFAULT_GRAPH_DEGREE = 64;
@@ -51,13 +49,9 @@ public class GPUSearchParams {
       CagraGraphBuildAlgo.NN_DESCENT;
   public static final IndexType DEFAULT_INDEX_TYPE = IndexType.CAGRA;
   public static final int DEFAULT_WRITER_THREADS = 32;
-  public static final int DEFAULT_M = 16;
-  public static final int DEFAULT_EF_CONSTRUCTION = 16;
   public static final Strategy DEFAULT_STRATEGY = Strategy.HEURISTIC;
-  public static final HnswHeuristicType DEFAULT_HEURISTIC_TYPE =
-      HnswHeuristicType.SAME_GRAPH_FOOTPRINT;
   public static final CuvsDistanceType DEFAULT_CUVS_DISTANCE_TYPE = CuvsDistanceType.L2Expanded;
-  public static final long DEFAULT_NN_DESCENT_NUM_ITERATIONS = 20;
+  public static final int DEFAULT_NN_DESCENT_NUM_ITERATIONS = 20;
 
   public static final Supplier<CuVSIvfPqParams> DEFAULT_IVF_PQ_PARAMS =
       () -> {
@@ -72,7 +66,7 @@ public class GPUSearchParams {
   private final CuVSIvfPqParams cuVSIvfPqParams;
   private final Strategy strategy;
   private final CuvsDistanceType cuvsDistanceType;
-  private final long nNDescentNumIterations;
+  private final int nnDescentNumIterations;
 
   /**
    * Constructs an instance of {@link GPUSearchParams} with specific parameter values.
@@ -83,12 +77,10 @@ public class GPUSearchParams {
    * @param cagraGraphBuildAlgo The CAGRA build algorithm to use.
    * @param indexType The type of index to build - CAGRA, BRUTEFORCE, or both.
    * @param cuVSIvfPqParams An instance of CuVSIvfPqParams containing IVF_PQ specific parameters.
-   * @param m defines The maximum number of bi-directional links (edges) per node.
-   * @param efConstruction Determines the size of the dynamic candidate list during graph construction.
    * @param strategy either HEURISTIC [Default] that automatically chooses build algorithm and its parameters based on data set size or CUSTOM that uses the parameters passed though this class.
    * @param heuristicType the heuristic type. The default option is SAME_GRAPH_FOOTPRINT.
    * @param cuvsDistanceType the cuvsDistanceType. The default option is L2Expanded.
-   * @param nNDescentNumIterations the number of Iterations to run if building with NN_DESCENT.
+   * @param nnDescentNumIterations the number of Iterations to run if building with NN_DESCENT.
    */
   private GPUSearchParams(
       int writerThreads,
@@ -99,7 +91,7 @@ public class GPUSearchParams {
       CuVSIvfPqParams cuVSIvfPqParams,
       Strategy strategy,
       CuvsDistanceType cuvsDistanceType,
-      long nNDescentNumIterations) {
+      int nnDescentNumIterations) {
     super();
     this.writerThreads = writerThreads;
     this.intermediateGraphDegree = intermediateGraphDegree;
@@ -109,7 +101,7 @@ public class GPUSearchParams {
     this.cuVSIvfPqParams = cuVSIvfPqParams;
     this.strategy = strategy;
     this.cuvsDistanceType = cuvsDistanceType;
-    this.nNDescentNumIterations = nNDescentNumIterations;
+    this.nnDescentNumIterations = nnDescentNumIterations;
   }
 
   /**
@@ -193,8 +185,8 @@ public class GPUSearchParams {
    *
    * @return the number of iterations for NN_DESCENT
    */
-  public long getnNDescentNumIterations() {
-    return nNDescentNumIterations;
+  public int getnNDescentNumIterations() {
+    return nnDescentNumIterations;
   }
 
   @Override
@@ -215,8 +207,8 @@ public class GPUSearchParams {
         + strategy
         + ", cuvsDistanceType="
         + cuvsDistanceType
-        + ", nNDescentNumIterations="
-        + nNDescentNumIterations
+        + ", nnDescentNumIterations="
+        + nnDescentNumIterations
         + "]";
   }
 
@@ -233,7 +225,7 @@ public class GPUSearchParams {
     private CuVSIvfPqParams cuVSIvfPqParams = null;
     private Strategy strategy = DEFAULT_STRATEGY;
     private CuvsDistanceType cuvsDistanceType = DEFAULT_CUVS_DISTANCE_TYPE;
-    private long nNDescentNumIterations = DEFAULT_NN_DESCENT_NUM_ITERATIONS;
+    private int nnDescentNumIterations = DEFAULT_NN_DESCENT_NUM_ITERATIONS;
 
     /**
      * Set the number of cuVS writer threads while building the index
@@ -343,11 +335,11 @@ public class GPUSearchParams {
      * Valid range - Minimum: {@value MIN_NN_DESCENT_NUM_ITERATIONS}, Maximum: {@value MAX_NN_DESCENT_NUM_ITERATIONS}
      * Default value - {@value DEFAULT_NN_DESCENT_NUM_ITERATIONS}
      *
-     * @param nNDescentNumIterations number of merge workers to set
+     * @param nnDescentNumIterations number of merge workers to set
      * @return instance of {@link Builder}
      */
-    public Builder withNNDescentNumIterations(int nNDescentNumIterations) {
-      this.nNDescentNumIterations = nNDescentNumIterations;
+    public Builder withNNDescentNumIterations(int nnDescentNumIterations) {
+      this.nnDescentNumIterations = nnDescentNumIterations;
       return this;
     }
 
@@ -394,10 +386,10 @@ public class GPUSearchParams {
       if (Objects.isNull(cuvsDistanceType)) {
         throw new IllegalArgumentException("cuvsDistanceType cannot be null.");
       }
-      if (nNDescentNumIterations < MIN_NN_DESCENT_NUM_ITERATIONS
-          || nNDescentNumIterations > MAX_NN_DESCENT_NUM_ITERATIONS) {
+      if (nnDescentNumIterations < MIN_NN_DESCENT_NUM_ITERATIONS
+          || nnDescentNumIterations > MAX_NN_DESCENT_NUM_ITERATIONS) {
         throw new IllegalArgumentException(
-            "nNDescentNumIterations not in valid range. Valid range: ["
+            "nnDescentNumIterations not in valid range. Valid range: ["
                 + MIN_NN_DESCENT_NUM_ITERATIONS
                 + ", "
                 + MAX_NN_DESCENT_NUM_ITERATIONS
@@ -424,7 +416,7 @@ public class GPUSearchParams {
           cuVSIvfPqParams,
           strategy,
           cuvsDistanceType,
-          nNDescentNumIterations);
+          nnDescentNumIterations);
     }
   }
 }

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
@@ -160,8 +160,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
               vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
 
       CagraIndexParams params =
-          AcceleratedHNSWUtils.getCagraIndexParams(
-              acceleratedHNSWParams, dataset.size(), dataset.columns());
+          CagraIndexParamsFactory.create(acceleratedHNSWParams, dataset.size(), dataset.columns());
 
       CagraIndex cagraIndex =
           CagraIndex.newBuilder(getCuVSResourcesInstance())

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
@@ -4,7 +4,6 @@
  */
 package com.nvidia.cuvs.lucene;
 
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.cagraIndexParams;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.createMultiLayerHnswGraph;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.createSingleVectorHnswGraph;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.printInfoStream;
@@ -159,13 +158,11 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
       CuVSMatrix dataset =
           Utils.createFloatMatrix(
               vectors, fieldInfo.getVectorDimension(), getCuVSResourcesInstance());
+
       CagraIndexParams params =
-          cagraIndexParams(
-              acceleratedHNSWParams.getWriterThreads(),
-              acceleratedHNSWParams.getIntermediateGraphDegree(),
-              acceleratedHNSWParams.getGraphdegree(),
-              acceleratedHNSWParams.getCagraGraphBuildAlgo(),
-              acceleratedHNSWParams.getCuVSIvfPqParams());
+          AcceleratedHNSWUtils.getCagraIndexParams(
+              acceleratedHNSWParams, dataset.size(), dataset.columns());
+
       CagraIndex cagraIndex =
           CagraIndex.newBuilder(getCuVSResourcesInstance())
               .withDataset(dataset)

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
@@ -164,8 +164,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter extends KnnVector
       }
 
       CagraIndexParams params =
-          AcceleratedHNSWUtils.getCagraIndexParams(
-              acceleratedHNSWParams, dataset.size(), dataset.columns());
+          CagraIndexParamsFactory.create(acceleratedHNSWParams, dataset.size(), dataset.columns());
 
       CagraIndex cagraIndex =
           CagraIndex.newBuilder(getCuVSResourcesInstance())

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
@@ -4,7 +4,6 @@
  */
 package com.nvidia.cuvs.lucene;
 
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.cagraIndexParams;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.createMultiLayerHnswGraph;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.createSingleVectorHnswGraph;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.printInfoStream;
@@ -165,12 +164,9 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter extends KnnVector
       }
 
       CagraIndexParams params =
-          cagraIndexParams(
-              acceleratedHNSWParams.getWriterThreads(),
-              acceleratedHNSWParams.getIntermediateGraphDegree(),
-              acceleratedHNSWParams.getGraphdegree(),
-              acceleratedHNSWParams.getCagraGraphBuildAlgo(),
-              acceleratedHNSWParams.getCuVSIvfPqParams());
+          AcceleratedHNSWUtils.getCagraIndexParams(
+              acceleratedHNSWParams, dataset.size(), dataset.columns());
+
       CagraIndex cagraIndex =
           CagraIndex.newBuilder(getCuVSResourcesInstance())
               .withDataset(dataset)

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
@@ -190,8 +190,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
       }
 
       CagraIndexParams params =
-          AcceleratedHNSWUtils.getCagraIndexParams(
-              acceleratedHNSWParams, dataset.size(), dataset.columns());
+          CagraIndexParamsFactory.create(acceleratedHNSWParams, dataset.size(), dataset.columns());
 
       CagraIndex cagraIndex =
           CagraIndex.newBuilder(getCuVSResourcesInstance())

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
@@ -4,7 +4,6 @@
  */
 package com.nvidia.cuvs.lucene;
 
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.cagraIndexParams;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.createMultiLayerHnswGraph;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.createSingleVectorHnswGraph;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.printInfoStream;
@@ -191,12 +190,9 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
       }
 
       CagraIndexParams params =
-          cagraIndexParams(
-              acceleratedHNSWParams.getWriterThreads(),
-              acceleratedHNSWParams.getIntermediateGraphDegree(),
-              acceleratedHNSWParams.getGraphdegree(),
-              acceleratedHNSWParams.getCagraGraphBuildAlgo(),
-              acceleratedHNSWParams.getCuVSIvfPqParams());
+          AcceleratedHNSWUtils.getCagraIndexParams(
+              acceleratedHNSWParams, dataset.size(), dataset.columns());
+
       CagraIndex cagraIndex =
           CagraIndex.newBuilder(getCuVSResourcesInstance())
               .withDataset(dataset)

--- a/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
@@ -7,23 +7,32 @@ package com.nvidia.cuvs.lucene;
 
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_BEAM_WIDTH;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_CUVS_DISTANCE_TYPE;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_HEURISTIC_TYPE;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_INT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_M;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_MAX_CONN;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_NUM_MERGE_WORKERS;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_STRATEGY;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_BEAM_WIDTH;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_M;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_MAX_CONN;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_BEAM_WIDTH;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_M;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_MAX_CONN;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_WRITER_THREADS;
@@ -56,6 +65,11 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
     assertEquals(DEFAULT_WRITER_THREADS, params.getWriterThreads());
     assertEquals(DEFAULT_NUM_MERGE_WORKERS, params.getNumMergeWorkers());
     assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
+    assertEquals(DEFAULT_M, params.getM());
+    assertEquals(DEFAULT_EF_CONSTRUCTION, params.getEfConstruction());
+    assertEquals(DEFAULT_STRATEGY, params.getStrategy());
+    assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
+    assertEquals(DEFAULT_HEURISTIC_TYPE, params.getHeuristicType());
   }
 
   @Test
@@ -150,6 +164,50 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
     assertThrows(
         IllegalArgumentException.class,
         () -> new AcceleratedHNSWParams.Builder().withCagraGraphBuildAlgo(null).build());
+  }
+
+  @Test
+  public void testAcceleratedHNSWParamsInvalidM() {
+    for (int v :
+        new int[] {random.nextInt(MIN_VALUE, MIN_M), random.nextInt(MAX_M + 1, MAX_VALUE)}) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new AcceleratedHNSWParams.Builder().withM(v).build());
+    }
+  }
+
+  @Test
+  public void testAcceleratedHNSWParamsInvalidefConstruction() {
+    for (int v :
+        new int[] {
+          random.nextInt(MIN_VALUE, MIN_EF_CONSTRUCTION),
+          random.nextInt(MAX_EF_CONSTRUCTION + 1, MAX_VALUE)
+        }) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new AcceleratedHNSWParams.Builder().withEfConstruction(v).build());
+    }
+  }
+
+  @Test
+  public void testAcceleratedHNSWParamsInvalidStrategy() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AcceleratedHNSWParams.Builder().withStrategy(null).build());
+  }
+
+  @Test
+  public void testAcceleratedHNSWParamsInvalidHnswHeuristicType() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AcceleratedHNSWParams.Builder().withHeuristicType(null).build());
+  }
+
+  @Test
+  public void testAcceleratedHNSWParamsInvalidCuvsDistanceType() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AcceleratedHNSWParams.Builder().withCuvsDistanceType(null).build());
   }
 
   @BeforeClass

--- a/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
@@ -63,7 +63,7 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
     assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
     assertEquals(DEFAULT_STRATEGY, params.getStrategy());
     assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
-    assertEquals(DEFAULT_NN_DESCENT_NUM_ITERATIONS, params.getnNDescentNumIterations());
+    assertEquals(DEFAULT_NN_DESCENT_NUM_ITERATIONS, params.getNNDescentNumIterations());
   }
 
   @Test

--- a/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
@@ -12,6 +12,7 @@ import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_GRAPH_DEGREE;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_INT_GRAPH_DEGREE;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_MAX_CONN;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_NN_DESCENT_NUM_ITERATIONS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_STRATEGY;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_WRITER_THREADS;
@@ -20,6 +21,7 @@ import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_INT_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_MAX_CONN;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_NN_DESCENT_NUM_ITERATIONS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_BEAM_WIDTH;
@@ -27,6 +29,7 @@ import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_INT_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_MAX_CONN;
+import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_NN_DESCENT_NUM_ITERATIONS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_WRITER_THREADS;
 import static java.lang.Integer.MAX_VALUE;
@@ -60,6 +63,7 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
     assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
     assertEquals(DEFAULT_STRATEGY, params.getStrategy());
     assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
+    assertEquals(DEFAULT_NN_DESCENT_NUM_ITERATIONS, params.getnNDescentNumIterations());
   }
 
   @Test
@@ -168,6 +172,19 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
     assertThrows(
         IllegalArgumentException.class,
         () -> new AcceleratedHNSWParams.Builder().withCuvsDistanceType(null).build());
+  }
+
+  @Test
+  public void testAcceleratedHNSWParamsInvalidNNDescentNumIterations() {
+    for (int v :
+        new int[] {
+          random.nextInt(MIN_VALUE, (int) MIN_NN_DESCENT_NUM_ITERATIONS),
+          random.nextInt((int) (MAX_NN_DESCENT_NUM_ITERATIONS + 1), MAX_VALUE)
+        }) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new AcceleratedHNSWParams.Builder().withNNDescentNumIterations(v).build());
+    }
   }
 
   @BeforeClass

--- a/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestAcceleratedHNSWParams.java
@@ -8,31 +8,24 @@ package com.nvidia.cuvs.lucene;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_BEAM_WIDTH;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_CUVS_DISTANCE_TYPE;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_GRAPH_DEGREE;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_HEURISTIC_TYPE;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_INT_GRAPH_DEGREE;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_M;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_MAX_CONN;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_STRATEGY;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.DEFAULT_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_BEAM_WIDTH;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_INT_GRAPH_DEG;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_M;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_MAX_CONN;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MAX_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_BEAM_WIDTH;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_HNSW_LAYERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_INT_GRAPH_DEG;
-import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_M;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_MAX_CONN;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_NUM_MERGE_WORKERS;
 import static com.nvidia.cuvs.lucene.AcceleratedHNSWParams.MIN_WRITER_THREADS;
@@ -65,11 +58,8 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
     assertEquals(DEFAULT_WRITER_THREADS, params.getWriterThreads());
     assertEquals(DEFAULT_NUM_MERGE_WORKERS, params.getNumMergeWorkers());
     assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
-    assertEquals(DEFAULT_M, params.getM());
-    assertEquals(DEFAULT_EF_CONSTRUCTION, params.getEfConstruction());
     assertEquals(DEFAULT_STRATEGY, params.getStrategy());
     assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
-    assertEquals(DEFAULT_HEURISTIC_TYPE, params.getHeuristicType());
   }
 
   @Test
@@ -167,40 +157,10 @@ public class TestAcceleratedHNSWParams extends LuceneTestCase {
   }
 
   @Test
-  public void testAcceleratedHNSWParamsInvalidM() {
-    for (int v :
-        new int[] {random.nextInt(MIN_VALUE, MIN_M), random.nextInt(MAX_M + 1, MAX_VALUE)}) {
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> new AcceleratedHNSWParams.Builder().withM(v).build());
-    }
-  }
-
-  @Test
-  public void testAcceleratedHNSWParamsInvalidefConstruction() {
-    for (int v :
-        new int[] {
-          random.nextInt(MIN_VALUE, MIN_EF_CONSTRUCTION),
-          random.nextInt(MAX_EF_CONSTRUCTION + 1, MAX_VALUE)
-        }) {
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> new AcceleratedHNSWParams.Builder().withEfConstruction(v).build());
-    }
-  }
-
-  @Test
   public void testAcceleratedHNSWParamsInvalidStrategy() {
     assertThrows(
         IllegalArgumentException.class,
         () -> new AcceleratedHNSWParams.Builder().withStrategy(null).build());
-  }
-
-  @Test
-  public void testAcceleratedHNSWParamsInvalidHnswHeuristicType() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new AcceleratedHNSWParams.Builder().withHeuristicType(null).build());
   }
 
   @Test

--- a/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
@@ -6,15 +6,24 @@
 package com.nvidia.cuvs.lucene;
 
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_CUVS_DISTANCE_TYPE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_HEURISTIC_TYPE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INDEX_TYPE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_M;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_STRATEGY;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_WRITER_THREADS;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_M;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_WRITER_THREADS;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_M;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_WRITER_THREADS;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
@@ -42,6 +51,11 @@ public class TestGPUSearchParams extends LuceneTestCase {
     assertEquals(DEFAULT_WRITER_THREADS, params.getWriterThreads());
     assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
     assertEquals(DEFAULT_INDEX_TYPE, params.getIndexType());
+    assertEquals(DEFAULT_M, params.getM());
+    assertEquals(DEFAULT_EF_CONSTRUCTION, params.getEfConstruction());
+    assertEquals(DEFAULT_STRATEGY, params.getStrategy());
+    assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
+    assertEquals(DEFAULT_HEURISTIC_TYPE, params.getHeuristicType());
   }
 
   @Test
@@ -94,6 +108,49 @@ public class TestGPUSearchParams extends LuceneTestCase {
     assertThrows(
         IllegalArgumentException.class,
         () -> new GPUSearchParams.Builder().withIndexType(null).build());
+  }
+
+  @Test
+  public void testGPUSearchParamsInvalidM() {
+    for (int v :
+        new int[] {random.nextInt(MIN_VALUE, MIN_M), random.nextInt(MAX_M + 1, MAX_VALUE)}) {
+      assertThrows(
+          IllegalArgumentException.class, () -> new GPUSearchParams.Builder().withM(v).build());
+    }
+  }
+
+  @Test
+  public void testGPUSearchParamsInvalidefConstruction() {
+    for (int v :
+        new int[] {
+          random.nextInt(MIN_VALUE, MIN_EF_CONSTRUCTION),
+          random.nextInt(MAX_EF_CONSTRUCTION + 1, MAX_VALUE)
+        }) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new GPUSearchParams.Builder().withEfConstruction(v).build());
+    }
+  }
+
+  @Test
+  public void testGPUSearchParamsInvalidStrategy() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new GPUSearchParams.Builder().withStrategy(null).build());
+  }
+
+  @Test
+  public void testGPUSearchParamsInvalidHnswHeuristicType() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new GPUSearchParams.Builder().withHeuristicType(null).build());
+  }
+
+  @Test
+  public void testGPUSearchParamsInvalidCuvsDistanceType() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new GPUSearchParams.Builder().withCuvsDistanceType(null).build());
   }
 
   @BeforeClass

--- a/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
@@ -7,23 +7,16 @@ package com.nvidia.cuvs.lucene;
 
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_CAGRA_GRAPH_BUILD_ALGO;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_CUVS_DISTANCE_TYPE;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_GRAPH_DEGREE;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_HEURISTIC_TYPE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INDEX_TYPE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INT_GRAPH_DEGREE;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_M;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_STRATEGY;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_WRITER_THREADS;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_INT_GRAPH_DEG;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_M;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_WRITER_THREADS;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_EF_CONSTRUCTION;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_INT_GRAPH_DEG;
-import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_M;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_WRITER_THREADS;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
@@ -51,11 +44,8 @@ public class TestGPUSearchParams extends LuceneTestCase {
     assertEquals(DEFAULT_WRITER_THREADS, params.getWriterThreads());
     assertEquals(DEFAULT_CAGRA_GRAPH_BUILD_ALGO, params.getCagraGraphBuildAlgo());
     assertEquals(DEFAULT_INDEX_TYPE, params.getIndexType());
-    assertEquals(DEFAULT_M, params.getM());
-    assertEquals(DEFAULT_EF_CONSTRUCTION, params.getEfConstruction());
     assertEquals(DEFAULT_STRATEGY, params.getStrategy());
     assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
-    assertEquals(DEFAULT_HEURISTIC_TYPE, params.getHeuristicType());
   }
 
   @Test
@@ -111,39 +101,10 @@ public class TestGPUSearchParams extends LuceneTestCase {
   }
 
   @Test
-  public void testGPUSearchParamsInvalidM() {
-    for (int v :
-        new int[] {random.nextInt(MIN_VALUE, MIN_M), random.nextInt(MAX_M + 1, MAX_VALUE)}) {
-      assertThrows(
-          IllegalArgumentException.class, () -> new GPUSearchParams.Builder().withM(v).build());
-    }
-  }
-
-  @Test
-  public void testGPUSearchParamsInvalidefConstruction() {
-    for (int v :
-        new int[] {
-          random.nextInt(MIN_VALUE, MIN_EF_CONSTRUCTION),
-          random.nextInt(MAX_EF_CONSTRUCTION + 1, MAX_VALUE)
-        }) {
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> new GPUSearchParams.Builder().withEfConstruction(v).build());
-    }
-  }
-
-  @Test
   public void testGPUSearchParamsInvalidStrategy() {
     assertThrows(
         IllegalArgumentException.class,
         () -> new GPUSearchParams.Builder().withStrategy(null).build());
-  }
-
-  @Test
-  public void testGPUSearchParamsInvalidHnswHeuristicType() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> new GPUSearchParams.Builder().withHeuristicType(null).build());
   }
 
   @Test

--- a/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestGPUSearchParams.java
@@ -10,13 +10,16 @@ import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_CUVS_DISTANCE_TYPE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_GRAPH_DEGREE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INDEX_TYPE;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_INT_GRAPH_DEGREE;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_NN_DESCENT_NUM_ITERATIONS;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_STRATEGY;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.DEFAULT_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_NN_DESCENT_NUM_ITERATIONS;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MAX_WRITER_THREADS;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_GRAPH_DEG;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_INT_GRAPH_DEG;
+import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_NN_DESCENT_NUM_ITERATIONS;
 import static com.nvidia.cuvs.lucene.GPUSearchParams.MIN_WRITER_THREADS;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.MIN_VALUE;
@@ -46,6 +49,7 @@ public class TestGPUSearchParams extends LuceneTestCase {
     assertEquals(DEFAULT_INDEX_TYPE, params.getIndexType());
     assertEquals(DEFAULT_STRATEGY, params.getStrategy());
     assertEquals(DEFAULT_CUVS_DISTANCE_TYPE, params.getCuvsDistanceType());
+    assertEquals(DEFAULT_NN_DESCENT_NUM_ITERATIONS, params.getnNDescentNumIterations());
   }
 
   @Test
@@ -112,6 +116,19 @@ public class TestGPUSearchParams extends LuceneTestCase {
     assertThrows(
         IllegalArgumentException.class,
         () -> new GPUSearchParams.Builder().withCuvsDistanceType(null).build());
+  }
+
+  @Test
+  public void testGPUSearchParamsInvalidNNDescentNumIterations() {
+    for (int v :
+        new int[] {
+          random.nextInt(MIN_VALUE, (int) MIN_NN_DESCENT_NUM_ITERATIONS),
+          random.nextInt((int) (MAX_NN_DESCENT_NUM_ITERATIONS + 1), MAX_VALUE)
+        }) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> new GPUSearchParams.Builder().withNNDescentNumIterations(v).build());
+    }
   }
 
   @BeforeClass


### PR DESCRIPTION
To introduce a heuristic approach to CAGRA build algorithm and its index parameter selection using underlying cuvs utilities. 

Summary of changes:

- Introduce a centralized approach to producing instances of `CagraIndexParams` via `CagraIndexParamsFactory`
- Add a parameter in the input parameter classes to select the strategy for either using the heuristic approach (default) that internally switches the cagra build algorithm based on the number of vectors and, most importantly, heuristically choose index build parameters for `IVF_PQ`, or a custom approach where everything, from the cagra build algorithm to its parameters, decided by the API user, is used internally.
- Update the value of `DEFAULT_WRITER_THREADS` to 32.

Fixes #134 