### PR TITLE
Cuvs-Lucene-139: Fix GPU OOMs && Java Heap OOMs

### DIFF
--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWParams.java
@@ -25,7 +25,7 @@ public class AcceleratedHNSWParams {
   public static final int MIN_GRAPH_DEG = 1;
   public static final int MAX_GRAPH_DEG = 512;
   public static final int MIN_HNSW_LAYERS = 1;
-  public static final int MAX_HNSW_LAYERS = 3;
+  public static final int MAX_HNSW_LAYERS = 99;
   public static final int MIN_MAX_CONN = 1;
   public static final int MAX_MAX_CONN = 512;
   public static final int MIN_BEAM_WIDTH = 1;

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -78,7 +78,10 @@ public class AcceleratedHNSWUtils {
    * Creates a multi-layer HNSW graph with dynamic number of layers.
    * M = cagraGraphDegree/2
    * Each layer contains 1/M nodes from the previous layer
-   * Creates layers until the highest layer has ≤ M nodes
+   * Creates layers until the highest layer has <= M nodes
+   * <p>
+   * This overload takes a {@code List<?>} as the vector source and is used
+   * by the flush path where vectors are already materialised on the Java heap.
    */
   public static GPUBuiltHnswGraph createMultiLayerHnswGraph(
       FieldInfo fieldInfo,
@@ -169,6 +172,90 @@ public class AcceleratedHNSWUtils {
     }
 
     // Create the multi-layer graph with all layers
+    return new GPUBuiltHnswGraph(size, dimensions, layerNodes, layerAdjacencies);
+  }
+
+  /**
+   * Creates a multi-layer HNSW graph with dynamic number of layers.
+   * M = cagraGraphDegree/2
+   * Each layer contains 1/M nodes from the previous layer
+   * Creates layers until the highest layer has <= M nodes
+   * <p>
+   * This overload takes a {@code CuVSMatrix} as the vector source and is used
+   * by the merge path. Vectors for higher-layer subsets are read directly from
+   * the native host matrix via {@link CuVSMatrix#getRow(long)} and
+   * {@link RowView#toArray(float[])}, avoiding any additional heap allocation
+   * of the full dataset.
+   */
+  public static GPUBuiltHnswGraph createMultiLayerHnswGraph(
+      FieldInfo fieldInfo,
+      int size,
+      int dimensions,
+      CuVSMatrix adjacencyListMatrix,
+      CuVSMatrix vectorDataset,
+      int hnswLayers,
+      int graphDegree,
+      CagraIndexParams params,
+      QuantizationType quantization)
+      throws Throwable {
+
+    int M = graphDegree / 2;
+
+    List<int[]> layerNodes = new ArrayList<>();
+    List<CuVSMatrix> layerAdjacencies = new ArrayList<>();
+
+    // Layer 0: Use full CAGRA adjacency list
+    layerNodes.add(null);
+    layerAdjacencies.add(adjacencyListMatrix);
+
+    int currentLayerSize = size;
+    int layerIndex = 1;
+    Random random = new Random();
+
+    while (layerIndex < hnswLayers && currentLayerSize > 1) {
+      int nextLayerSize = Math.max(2, currentLayerSize / M);
+      SortedSet<Integer> selectedNodesSet = new TreeSet<>();
+
+      if (layerIndex == 1) {
+        while (selectedNodesSet.size() < nextLayerSize) {
+          selectedNodesSet.add(random.nextInt(size));
+        }
+      } else {
+        int[] prevLayerNodes = layerNodes.get(layerNodes.size() - 1);
+        while (selectedNodesSet.size() < nextLayerSize) {
+          selectedNodesSet.add(prevLayerNodes[random.nextInt(prevLayerNodes.length)]);
+        }
+      }
+
+      int[] selectedNodes =
+          selectedNodesSet.stream().mapToInt(Integer::intValue).sorted().toArray();
+      layerNodes.add(selectedNodes);
+
+      if (quantization == QuantizationType.NONE) {
+        // Read only the sampled rows from the native matrix — no full-dataset heap copy
+        float[][] selectedVectors = new float[nextLayerSize][dimensions];
+        for (int i = 0; i < nextLayerSize; i++) {
+          vectorDataset.getRow(selectedNodes[i]).toArray(selectedVectors[i]);
+        }
+        layerAdjacencies.add(
+            buildCagraGraphForSubset(
+                selectedVectors, selectedNodes, 0, params, dimensions, quantization));
+      } else {
+        int bytesPerVector = (dimensions + 7) / 8;
+        byte[][] selectedVectors = new byte[nextLayerSize][bytesPerVector];
+        for (int i = 0; i < nextLayerSize; i++) {
+          vectorDataset.getRow(selectedNodes[i]).toArray(selectedVectors[i]);
+        }
+        layerAdjacencies.add(
+            buildCagraGraphForSubset(
+                selectedVectors, selectedNodes, bytesPerVector, params, dimensions, quantization));
+      }
+
+      currentLayerSize = nextLayerSize;
+      layerIndex++;
+      random = new Random(new Random().nextLong());
+    }
+
     return new GPUBuiltHnswGraph(size, dimensions, layerNodes, layerAdjacencies);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
@@ -17,12 +17,12 @@ import static com.nvidia.cuvs.lucene.Lucene99AcceleratedHNSWVectorsFormat.HNSW_M
 import static com.nvidia.cuvs.lucene.Lucene99AcceleratedHNSWVectorsFormat.HNSW_META_CODEC_NAME;
 import static com.nvidia.cuvs.lucene.ThreadLocalCuVSResourcesProvider.closeCuVSResourcesInstance;
 import static com.nvidia.cuvs.lucene.ThreadLocalCuVSResourcesProvider.getCuVSResourcesInstance;
-import static com.nvidia.cuvs.lucene.Utils.createListFromMergedVectors;
 import static org.apache.lucene.index.VectorEncoding.FLOAT32;
 import static org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance;
 
 import com.nvidia.cuvs.CagraIndex;
 import com.nvidia.cuvs.CagraIndexParams;
+import com.nvidia.cuvs.CuVSHostMatrix;
 import com.nvidia.cuvs.CuVSMatrix;
 import com.nvidia.cuvs.lucene.AcceleratedHNSWUtils.QuantizationType;
 import java.io.IOException;
@@ -35,11 +35,14 @@ import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsWriter;
 import org.apache.lucene.index.DocsWithFieldSet;
 import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.index.KnnVectorValues;
 import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
 import org.apache.lucene.index.Sorter.DocMap;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.InfoStream;
@@ -141,6 +144,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
 
   /**
    * Builds the intermediate CAGRA index and builds and writes the HNSW index.
+   * Used by the flush path (operates on an in-memory List<float[]>).
    *
    * @param fieldInfo instance of FieldInfo that has the field description
    * @param vectors vectors to index
@@ -181,6 +185,74 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
               dimensions,
               adjacencyListMatrix,
               vectors,
+              acceleratedHNSWParams.getHnswLayers(),
+              acceleratedHNSWParams.getGraphdegree(),
+              params,
+              QuantizationType.NONE);
+      long vectorIndexOffset = hnswVectorIndex.getFilePointer();
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
+      writeMeta(
+          hnswVectorIndex,
+          hnswMeta,
+          fieldInfo,
+          vectorIndexOffset,
+          vectorIndexLength,
+          size,
+          hnswGraph,
+          graphLevelNodeOffsets,
+          acceleratedHNSWParams.getGraphdegree());
+      cagraIndex.close();
+    } catch (Throwable t) {
+      Utils.handleThrowable(t);
+    }
+  }
+
+  /**
+   * Builds the intermediate CAGRA index and builds and writes the HNSW index.
+   * Used by the merge path (operates on a pre-built CuVSHostMatrix to avoid
+   * double-materializing the full dataset on heap and in native memory simultaneously).
+   *
+   * @param fieldInfo instance of FieldInfo that has the field description
+   * @param dataset   pre-built host-memory matrix of all merged vectors
+   * @param size      number of vectors in the dataset
+   * @throws IOException
+   */
+  private void writeFieldInternal(FieldInfo fieldInfo, CuVSHostMatrix dataset, int size)
+      throws IOException {
+    if (size == 0) {
+      writeEmpty(fieldInfo, hnswMeta);
+      return;
+    }
+    if (size < 2) {
+      int dims = fieldInfo.getVectorDimension();
+      float[] buf = new float[dims];
+      dataset.getRow(0).toArray(buf);
+      writeSingleVectorGraph(fieldInfo, List.of(buf));
+      return;
+    }
+    try {
+      CagraIndexParams params =
+          cagraIndexParams(
+              acceleratedHNSWParams.getWriterThreads(),
+              acceleratedHNSWParams.getIntermediateGraphDegree(),
+              acceleratedHNSWParams.getGraphdegree(),
+              acceleratedHNSWParams.getCagraGraphBuildAlgo(),
+              acceleratedHNSWParams.getCuVSIvfPqParams());
+      CagraIndex cagraIndex =
+          CagraIndex.newBuilder(getCuVSResourcesInstance())
+              .withDataset(dataset)
+              .withIndexParams(params)
+              .build();
+      CuVSMatrix adjacencyListMatrix = cagraIndex.getGraph();
+      int dimensions = fieldInfo.getVectorDimension();
+      GPUBuiltHnswGraph hnswGraph =
+          createMultiLayerHnswGraph(
+              fieldInfo,
+              size,
+              dimensions,
+              adjacencyListMatrix,
+              dataset,
               acceleratedHNSWParams.getHnswLayers(),
               acceleratedHNSWParams.getGraphdegree(),
               params,
@@ -280,14 +352,25 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
   }
 
   /**
-   * Create combined data set for the merged segment and call writeFieldInternal.
+   * Streams merged vectors directly into a native host-memory matrix (CuVSHostMatrix)
+   * without materialising a List<float[]> on the Java heap, then calls writeFieldInternal.
+   * This avoids the double-copy OOM (heap list + native matrix simultaneously) that
+   * occurs when force-merging large segments.
    */
   private void vectorBasedMerge(FieldInfo fieldInfo, MergeState mergeState) throws IOException {
     try {
-      List<float[]> dataset =
-          createListFromMergedVectors(
-              KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState));
-      writeFieldInternal(fieldInfo, dataset);
+      FloatVectorValues mergedVectors =
+          KnnVectorsWriter.MergedVectorValues.mergeFloatVectorValues(fieldInfo, mergeState);
+      int size = mergedVectors.size();
+      int dims = fieldInfo.getVectorDimension();
+      CuVSMatrix.Builder<CuVSHostMatrix> builder =
+          CuVSMatrix.hostBuilder(size, dims, CuVSMatrix.DataType.FLOAT);
+      KnnVectorValues.DocIndexIterator it = mergedVectors.iterator();
+      for (int doc = it.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = it.nextDoc()) {
+        builder.addVector(mergedVectors.vectorValue(it.index()));
+      }
+      CuVSHostMatrix dataset = builder.build();
+      writeFieldInternal(fieldInfo, dataset, size);
     } catch (Throwable t) {
       Utils.handleThrowable(t);
     }

--- a/src/main/java/com/nvidia/cuvs/lucene/Utils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Utils.java
@@ -54,20 +54,12 @@ public class Utils {
    * @return an instance of CuVSMatrix
    */
   static CuVSMatrix createFloatMatrix(List<float[]> data, int dimensions, CuVSResources resources) {
-    // Use Builder pattern to avoid intermediate float[][] allocation
-    // and copy directly from List to device memory
     CuVSMatrix.Builder<?> builder =
-        CuVSMatrix.deviceBuilder(
-            resources,
-            data.size(), // rows (number of vectors)
-            dimensions, // columns (vector dimension)
-            CuVSMatrix.DataType.FLOAT);
-
-    // Add vectors one by one - builder copies directly to device memory
+        CuVSMatrix.hostBuilder( // was: CuVSMatrix.deviceBuilder(resources, ...
+            data.size(), dimensions, CuVSMatrix.DataType.FLOAT);
     for (float[] vector : data) {
       builder.addVector(vector);
     }
-
     return builder.build();
   }
 
@@ -84,20 +76,12 @@ public class Utils {
    */
   static CuVSMatrix createByteMatrix(
       List<byte[]> data, int bytesPerVector, CuVSResources resources) {
-    // Use Builder pattern to avoid intermediate byte[][] allocation
-    // and copy directly from List to device memory
     CuVSMatrix.Builder<?> builder =
-        CuVSMatrix.deviceBuilder(
-            resources,
-            data.size(), // rows (number of vectors)
-            bytesPerVector, // columns (bytes per vector)
-            CuVSMatrix.DataType.BYTE);
-
-    // Add vectors one by one - builder copies directly to device memory
+        CuVSMatrix.hostBuilder( // was: CuVSMatrix.deviceBuilder(resources, ...
+            data.size(), bytesPerVector, CuVSMatrix.DataType.BYTE);
     for (byte[] vector : data) {
       builder.addVector(vector);
     }
-
     return builder.build();
   }
 
@@ -112,13 +96,8 @@ public class Utils {
   static CuVSMatrix createByteMatrixFromArray(
       byte[][] data, int bytesPerVector, CuVSResources resources) {
     CuVSMatrix.Builder<?> builder =
-        CuVSMatrix.deviceBuilder(
-            resources,
-            data.length, // rows (number of vectors)
-            bytesPerVector, // columns (bytes per vector)
-            CuVSMatrix.DataType.BYTE);
-
-    // Add vectors one by one - builder copies directly to device memory
+        CuVSMatrix.hostBuilder( // was: CuVSMatrix.deviceBuilder(resources, ...
+            data.length, bytesPerVector, CuVSMatrix.DataType.BYTE);
     for (byte[] vector : data) {
       builder.addVector(vector);
     }


### PR DESCRIPTION
GPU OOM fix:
Replaced usage of CuVSMatrix.deviceBuilder with usage of CuVSMatrix.hostBuilder instead. deviceBuilder was eagerly loading the full dataset to GPU. using hostBuilder gives responsibility to CAGRA as to how to optimally stream data from host memory to GPU.

Java Heap OOM fix:
Stream subsets of data during HNSW graph construction instead of trying to load the full dataset onto the Java Heap.

Note: this PR also includes the commit from cuvs-lucene-137 (https://github.com/rapidsai/cuvs-lucene/issues/137)