### PR TITLE
Lucene upgrade to v10.4, fix lucene compatibility issue

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -30,18 +30,18 @@
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-codecs</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-backward-codecs</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
     </dependency>
     <dependency>
         <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>com.nvidia.cuvs.lucene</groupId>
   <artifactId>cuvs-lucene</artifactId>
   <!-- NOTE: The version automatically gets updated when ci/release/update-version.sh is invoked. -->
-  <!--CUVS_LUCENE#VERSION_UPDATE_MARKER_START--><version>26.06.0</version><!--CUVS_LUCENE#VERSION_UPDATE_MARKER_END-->
+  <!--CUVS_LUCENE#VERSION_UPDATE_MARKER_START--><version>26.04.0</version><!--CUVS_LUCENE#VERSION_UPDATE_MARKER_END-->
   <name>cuvs-lucene</name>
   <packaging>jar</packaging>
 
@@ -47,23 +47,23 @@
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-codecs</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-backward-codecs</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-test-framework</artifactId>
-        <version>10.2.0</version>
+        <version>10.4.0</version>
         <scope>test</scope>
     </dependency>
     <dependency>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.nvidia.cuvs</groupId>
       <artifactId>cuvs-java</artifactId>
-      <!--CUVS_LUCENE#VERSION_UPDATE_MARKER_START--><version>26.06.0</version><!--CUVS_LUCENE#VERSION_UPDATE_MARKER_END-->
+      <!--CUVS_LUCENE#VERSION_UPDATE_MARKER_START--><version>26.04.0</version><!--CUVS_LUCENE#VERSION_UPDATE_MARKER_END-->
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -43,7 +43,7 @@ public class AcceleratedHNSWUtils {
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       VECTOR_SIMILARITY_FUNCTIONS = LUCENE_PROVIDER.getSimilarityFunctions();
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e.getMessage());
@@ -230,13 +230,6 @@ public class AcceleratedHNSWUtils {
     return CuVSMatrix.ofArray(remappedAdjacency);
   }
 
-  /**
-   * Version at which Lucene uses GroupVarInt for HNSW neighbor encoding (1 in 10.3.x). When format
-   * version >= this value, neighbors are written with {@link IndexOutput#writeGroupVInts(int[],
-   * int)} for compatibility with Lucene99HnswVectorsReader.
-   */
-  private static final int VERSION_GROUPVARINT = 1;
-
   private static int[] getSortedNodes(NodesIterator nodesOnLevel) {
     int[] nodes = new int[nodesOnLevel.size()];
     int consumed = nodesOnLevel.consume(nodes);
@@ -246,16 +239,16 @@ public class AcceleratedHNSWUtils {
   }
 
   /**
-   * Returns a 2D array of offsets (information written while writing the meta info)
+   * Returns a 2D array of offsets (information written while writing the meta info). Neighbor ids
+   * are written with {@link IndexOutput#writeGroupVInts(int[], int)} to match Apache Lucene 10.4
+   * {@code Lucene99HnswVectorsFormat} (GroupVarInt encoding).
    *
    * @param graph instance of GPUBuiltHnswGraph
    * @param vectorIndex instance of IndexOutput
-   * @param version format version (e.g. Lucene99HnswVectorsFormat.VERSION_CURRENT). When >= {@link
-   *     #VERSION_GROUPVARINT}, neighbors are written with GroupVarInt for Lucene 10.3.x compat.
    * @return a 2D array of offsets
    * @throws IOException I/O Exceptions
    */
-  public static int[][] writeGraph(GPUBuiltHnswGraph graph, IndexOutput vectorIndex, int version)
+  public static int[][] writeGraph(GPUBuiltHnswGraph graph, IndexOutput vectorIndex)
       throws IOException {
     // write vectors' neighbors on each level into the vectorIndex file
     int countOnLevel0 = graph.size();
@@ -295,14 +288,7 @@ public class AcceleratedHNSWUtils {
         }
         // Write the size after duplicates are removed
         vectorIndex.writeVInt(actualSize);
-        // Write de-duplicated neighbors (GroupVarInt when version >= 1 for Lucene 10.3.x compat)
-        if (version >= VERSION_GROUPVARINT) {
-          vectorIndex.writeGroupVInts(scratch, actualSize);
-        } else {
-          for (int i = 0; i < actualSize; i++) {
-            vectorIndex.writeVInt(scratch[i]);
-          }
-        }
+        vectorIndex.writeGroupVInts(scratch, actualSize);
         offsets[level][nodeOffsetId++] =
             Math.toIntExact(vectorIndex.getFilePointer() - offsetStart);
       }

--- a/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/AcceleratedHNSWUtils.java
@@ -231,21 +231,38 @@ public class AcceleratedHNSWUtils {
   }
 
   /**
+   * Version at which Lucene uses GroupVarInt for HNSW neighbor encoding (1 in 10.3.x). When format
+   * version >= this value, neighbors are written with {@link IndexOutput#writeGroupVInts(int[],
+   * int)} for compatibility with Lucene99HnswVectorsReader.
+   */
+  private static final int VERSION_GROUPVARINT = 1;
+
+  private static int[] getSortedNodes(NodesIterator nodesOnLevel) {
+    int[] nodes = new int[nodesOnLevel.size()];
+    int consumed = nodesOnLevel.consume(nodes);
+    assert consumed == nodesOnLevel.size();
+    Arrays.sort(nodes);
+    return nodes;
+  }
+
+  /**
    * Returns a 2D array of offsets (information written while writing the meta info)
    *
    * @param graph instance of GPUBuiltHnswGraph
    * @param vectorIndex instance of IndexOutput
+   * @param version format version (e.g. Lucene99HnswVectorsFormat.VERSION_CURRENT). When >= {@link
+   *     #VERSION_GROUPVARINT}, neighbors are written with GroupVarInt for Lucene 10.3.x compat.
    * @return a 2D array of offsets
    * @throws IOException I/O Exceptions
    */
-  public static int[][] writeGraph(GPUBuiltHnswGraph graph, IndexOutput vectorIndex)
+  public static int[][] writeGraph(GPUBuiltHnswGraph graph, IndexOutput vectorIndex, int version)
       throws IOException {
     // write vectors' neighbors on each level into the vectorIndex file
     int countOnLevel0 = graph.size();
     int[][] offsets = new int[graph.numLevels()][];
     int[] scratch = new int[graph.maxConn() * 2];
     for (int level = 0; level < graph.numLevels(); level++) {
-      int[] sortedNodes = NodesIterator.getSortedNodes(graph.getNodesOnLevel(level));
+      int[] sortedNodes = getSortedNodes(graph.getNodesOnLevel(level));
       offsets[level] = new int[sortedNodes.length];
       int nodeOffsetId = 0;
 
@@ -278,9 +295,13 @@ public class AcceleratedHNSWUtils {
         }
         // Write the size after duplicates are removed
         vectorIndex.writeVInt(actualSize);
-        // Write de-duplicated neighbors
-        for (int i = 0; i < actualSize; i++) {
-          vectorIndex.writeVInt(scratch[i]);
+        // Write de-duplicated neighbors (GroupVarInt when version >= 1 for Lucene 10.3.x compat)
+        if (version >= VERSION_GROUPVARINT) {
+          vectorIndex.writeGroupVInts(scratch, actualSize);
+        } else {
+          for (int i = 0; i < actualSize; i++) {
+            vectorIndex.writeVInt(scratch[i]);
+          }
         }
         offsets[level][nodeOffsetId++] =
             Math.toIntExact(vectorIndex.getFilePointer() - offsetStart);

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUSearchCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUSearchCodec.java
@@ -29,7 +29,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
    * @throws Exception
    */
   public CuVS2510GPUSearchCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
     initializeFormat(new GPUSearchParams.Builder().build());
   }
 
@@ -53,7 +53,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
    * @throws Exception Exception raised when initializing the codec
    */
   public CuVS2510GPUSearchCodec(GPUSearchParams params) throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
     initializeFormat(params);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUSearchCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUSearchCodec.java
@@ -29,7 +29,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
    * @throws Exception
    */
   public CuVS2510GPUSearchCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
     initializeFormat(new GPUSearchParams.Builder().build());
   }
 
@@ -53,7 +53,7 @@ public class CuVS2510GPUSearchCodec extends FilterCodec {
    * @throws Exception Exception raised when initializing the codec
    */
   public CuVS2510GPUSearchCodec(GPUSearchParams params) throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
     initializeFormat(params);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsFormat.java
@@ -39,7 +39,7 @@ public class CuVS2510GPUVectorsFormat extends KnnVectorsFormat {
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       FLAT_VECTORS_FORMAT =
           LUCENE_PROVIDER.getLuceneFlatVectorsFormatInstance(DefaultFlatVectorScorer.INSTANCE);
     } catch (Exception e) {

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -40,13 +40,14 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.internal.hppc.IntObjectHashMap;
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IOContext.Context;
 import org.apache.lucene.store.IndexInput;
-import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.hnsw.IntToIntFunction;
@@ -111,8 +112,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
       } finally {
         CodecUtil.checkFooter(meta, priorException);
       }
-      var ioContext = state.context.withReadAdvice(ReadAdvice.SEQUENTIAL);
-      cuvsIndexInput = openCuVSInput(state, versionMeta, ioContext);
+      cuvsIndexInput = openCuVSInput(state, versionMeta, state.context);
       /*
        * Only load indexes on the GPU when this reader is opening for searches.
        * Do not load indexes on the GPU when this reader is opening during merge calls.
@@ -393,10 +393,62 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
   }
 
   /**
+   * Maps live-document acceptance to vector ordinals. {@link AcceptDocs#bits()} may be null in
+   * Lucene 10.4+ while {@link FloatVectorValues#getAcceptOrds} returns null when passed null bits;
+   * this method fills that gap for GPU prefilter construction.
+   */
+  private static Bits computeAcceptedOrds(FloatVectorValues rawValues, AcceptDocs acceptDocs)
+      throws IOException {
+    if (acceptDocs == null) {
+      return null;
+    }
+    Bits live = acceptDocs.bits();
+    if (live != null) {
+      Bits mapped = rawValues.getAcceptOrds(live);
+      if (mapped != null) {
+        return mapped;
+      }
+    }
+    final Bits docAccept;
+    if (live != null) {
+      docAccept = live;
+    } else {
+      BitSet docBits = new BitSet();
+      DocIdSetIterator disi = acceptDocs.iterator();
+      for (int doc = disi.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = disi.nextDoc()) {
+        docBits.set(doc);
+      }
+      docAccept =
+          new Bits() {
+            @Override
+            public boolean get(int docId) {
+              return docBits.get(docId);
+            }
+
+            @Override
+            public int length() {
+              return docBits.length();
+            }
+          };
+    }
+    return new Bits() {
+      @Override
+      public boolean get(int ord) {
+        return docAccept.get(rawValues.ordToDoc(ord));
+      }
+
+      @Override
+      public int length() {
+        return rawValues.size();
+      }
+    };
+  }
+
+  /**
    * Returns the k nearest neighbor documents using cuVS's CAGRA or brute force algorithm for this field, to the given vector.
    */
   @Override
-  public void search(String field, float[] target, KnnCollector knnCollector, Bits acceptDocs)
+  public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     var fieldEntry = getFieldEntry(field, VectorEncoding.FLOAT32);
     if (fieldEntry.count() == 0 || knnCollector.k() == 0) {
@@ -410,12 +462,13 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
     }
 
     final FloatVectorValues rawValues = flatVectorsReader.getFloatVectorValues(field);
-    final Bits acceptedOrds = rawValues.getAcceptOrds(acceptDocs);
+    final Bits acceptedOrds = computeAcceptedOrds(rawValues, acceptDocs);
     BitSet[] mask = null;
     int maskLength = 0;
     int topK = knnCollector.k();
 
     if (acceptDocs != null) {
+      assert acceptedOrds != null;
       mask = new BitSet[1]; // As there is only one query "target"
       mask[0] = new BitSet(acceptedOrds.length());
       /*
@@ -528,7 +581,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
    * This is not supported.
    */
   @Override
-  public void search(String field, byte[] target, KnnCollector knnCollector, Bits acceptDocs)
+  public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs)
       throws IOException {
     throw new UnsupportedOperationException("Byte vectors are not currently supported");
   }

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsReader.java
@@ -70,7 +70,7 @@ public class CuVS2510GPUVectorsReader extends KnnVectorsReader {
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       VECTOR_SIMILARITY_FUNCTIONS = LUCENE_PROVIDER.getSimilarityFunctions();
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e.getMessage());

--- a/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/CuVS2510GPUVectorsWriter.java
@@ -73,7 +73,7 @@ public class CuVS2510GPUVectorsWriter extends KnnVectorsWriter {
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       VECTOR_SIMILARITY_FUNCTIONS = LUCENE_PROVIDER.getSimilarityFunctions();
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e.getMessage());

--- a/src/main/java/com/nvidia/cuvs/lucene/GPUKnnFloatVectorQuery.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/GPUKnnFloatVectorQuery.java
@@ -7,11 +7,11 @@ package com.nvidia.cuvs.lucene;
 import java.io.IOException;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.knn.KnnCollectorManager;
-import org.apache.lucene.util.Bits;
 
 /**
  * Extends upon KnnFloatVectorQuery for GPU-only search.
@@ -43,7 +43,7 @@ public class GPUKnnFloatVectorQuery extends KnnFloatVectorQuery {
   @Override
   protected TopDocs approximateSearch(
       LeafReaderContext context,
-      Bits acceptDocs,
+      AcceptDocs acceptDocs,
       int visitedLimit,
       KnnCollectorManager knnCollectorManager)
       throws IOException {

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene101AcceleratedHNSWCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene101AcceleratedHNSWCodec.java
@@ -30,7 +30,7 @@ public class Lucene101AcceleratedHNSWCodec extends FilterCodec {
    * @throws Exception
    */
   public Lucene101AcceleratedHNSWCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
   }
 
   /**
@@ -52,7 +52,7 @@ public class Lucene101AcceleratedHNSWCodec extends FilterCodec {
    */
   public Lucene101AcceleratedHNSWCodec(AcceleratedHNSWParams acceleratedHNSWParams)
       throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
     initializeFormat(acceleratedHNSWParams);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene101AcceleratedHNSWCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene101AcceleratedHNSWCodec.java
@@ -30,7 +30,7 @@ public class Lucene101AcceleratedHNSWCodec extends FilterCodec {
    * @throws Exception
    */
   public Lucene101AcceleratedHNSWCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
   }
 
   /**
@@ -52,7 +52,7 @@ public class Lucene101AcceleratedHNSWCodec extends FilterCodec {
    */
   public Lucene101AcceleratedHNSWCodec(AcceleratedHNSWParams acceleratedHNSWParams)
       throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
     initializeFormat(acceleratedHNSWParams);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsFormat.java
@@ -40,7 +40,7 @@ public class Lucene99AcceleratedHNSWVectorsFormat extends KnnVectorsFormat {
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       FLAT_VECTORS_FORMAT =
           LUCENE_PROVIDER.getLuceneFlatVectorsFormatInstance(DefaultFlatVectorScorer.INSTANCE);
     } catch (Exception e) {

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
@@ -186,7 +186,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
               params,
               QuantizationType.NONE);
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
       writeMeta(
           hnswVectorIndex,
@@ -262,7 +262,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
       int dimensions = fieldInfo.getVectorDimension();
       GPUBuiltHnswGraph hnswGraph = createSingleVectorHnswGraph(size, dimensions);
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
       writeMeta(
           hnswVectorIndex,

--- a/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/Lucene99AcceleratedHNSWVectorsWriter.java
@@ -70,7 +70,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       VERSION_CURRENT = LUCENE_PROVIDER.getStaticIntParam("VERSION_CURRENT");
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e.getMessage());
@@ -186,7 +186,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
               params,
               QuantizationType.NONE);
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
       writeMeta(
           hnswVectorIndex,
@@ -262,7 +262,7 @@ public class Lucene99AcceleratedHNSWVectorsWriter extends KnnVectorsWriter {
       int dimensions = fieldInfo.getVectorDimension();
       GPUBuiltHnswGraph hnswGraph = createSingleVectorHnswGraph(size, dimensions);
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
       writeMeta(
           hnswVectorIndex,

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedCodec.java
@@ -25,7 +25,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedCodec extends FilterCodec {
   private KnnVectorsFormat format;
 
   public LuceneAcceleratedHNSWBinaryQuantizedCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
   }
 
   public LuceneAcceleratedHNSWBinaryQuantizedCodec(String name, Codec delegate) {
@@ -35,7 +35,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedCodec extends FilterCodec {
 
   public LuceneAcceleratedHNSWBinaryQuantizedCodec(AcceleratedHNSWParams acceleratedHNSWParams)
       throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
     initializeFormat(acceleratedHNSWParams);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedCodec.java
@@ -25,7 +25,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedCodec extends FilterCodec {
   private KnnVectorsFormat format;
 
   public LuceneAcceleratedHNSWBinaryQuantizedCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
   }
 
   public LuceneAcceleratedHNSWBinaryQuantizedCodec(String name, Codec delegate) {
@@ -35,7 +35,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedCodec extends FilterCodec {
 
   public LuceneAcceleratedHNSWBinaryQuantizedCodec(AcceleratedHNSWParams acceleratedHNSWParams)
       throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
     initializeFormat(acceleratedHNSWParams);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat.java
@@ -35,7 +35,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat extends KnnVector
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("104");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_CODEC_LINE);
       FLAT_VECTORS_FORMAT =
           LUCENE_PROVIDER.getLuceneFlatVectorsFormatInstance(DefaultFlatVectorScorer.INSTANCE);
     } catch (Exception e) {
@@ -77,14 +77,13 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat extends KnnVector
           state, acceleratedHNSWParams, flatWriter);
     } else {
       try {
-        // Fallback to Lucene's Lucene102HnswBinaryQuantizedVectorsFormat format
+        // Lucene 10.4: binary-quantized HNSW lives in backward_codecs.lucene102
         log.log(
             Level.WARNING,
             "GPU based indexing not supported, falling back to using the"
-                + " Lucene104HnswBinaryQuantizedVectorsFormat");
+                + " Lucene102HnswBinaryQuantizedVectorsFormat (backward-codecs)");
         KnnVectorsFormat fallbackFormat =
-            LUCENE_PROVIDER.getLuceneHnswBinaryQuantizedVectorsFormatInstance(
-                acceleratedHNSWParams.getMaxConn(), acceleratedHNSWParams.getBeamWidth());
+            LUCENE_PROVIDER.getLuceneHnswBinaryQuantizedVectorsFormatInstance();
         return fallbackFormat.fieldsWriter(state);
       } catch (Exception e) {
         throw new RuntimeException(e.getMessage());

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat.java
@@ -27,8 +27,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat extends KnnVector
 
   private static final Logger log =
       Logger.getLogger(LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat.class.getName());
-  private static final LuceneProvider LUCENE102_PROVIDER;
-  private static final LuceneProvider LUCENE99_PROVIDER;
+  private static final LuceneProvider LUCENE_PROVIDER;
   private static final FlatVectorsFormat FLAT_VECTORS_FORMAT;
   private static final int MAX_DIMENSIONS = 4096;
 
@@ -36,12 +35,11 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat extends KnnVector
 
   static {
     try {
-      LUCENE99_PROVIDER = LuceneProvider.getInstance("99");
-      LUCENE102_PROVIDER = LuceneProvider.getInstance("102");
+      LUCENE_PROVIDER = LuceneProvider.getInstance("104");
       FLAT_VECTORS_FORMAT =
-          LUCENE102_PROVIDER.getLuceneFlatVectorsFormatInstance(DefaultFlatVectorScorer.INSTANCE);
+          LUCENE_PROVIDER.getLuceneFlatVectorsFormatInstance(DefaultFlatVectorScorer.INSTANCE);
     } catch (Exception e) {
-      throw new ExceptionInInitializerError(e.getMessage());
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -83,9 +81,9 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat extends KnnVector
         log.log(
             Level.WARNING,
             "GPU based indexing not supported, falling back to using the"
-                + " Lucene102HnswBinaryQuantizedVectorsFormat");
+                + " Lucene104HnswBinaryQuantizedVectorsFormat");
         KnnVectorsFormat fallbackFormat =
-            LUCENE102_PROVIDER.getLuceneHnswBinaryQuantizedVectorsFormatInstance(
+            LUCENE_PROVIDER.getLuceneHnswBinaryQuantizedVectorsFormatInstance(
                 acceleratedHNSWParams.getMaxConn(), acceleratedHNSWParams.getBeamWidth());
         return fallbackFormat.fieldsWriter(state);
       } catch (Exception e) {
@@ -100,7 +98,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat extends KnnVector
   @Override
   public KnnVectorsReader fieldsReader(SegmentReadState state) throws IOException {
     try {
-      return LUCENE99_PROVIDER.getLuceneHnswVectorsReaderInstance(
+      return LUCENE_PROVIDER.getLuceneHnswVectorsReaderInstance(
           state, FLAT_VECTORS_FORMAT.fieldsReader(state));
     } catch (Exception e) {
       throw new RuntimeException(e.getMessage());

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
@@ -195,7 +195,8 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter extends KnnVector
 
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      int[][] graphLevelNodeOffsets =
+          writeGraph(hnswGraph, hnswVectorIndex, Lucene99HnswVectorsFormat.VERSION_CURRENT);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 
       // Write metadata
@@ -284,7 +285,8 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter extends KnnVector
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
 
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      int[][] graphLevelNodeOffsets =
+          writeGraph(hnswGraph, hnswVectorIndex, Lucene99HnswVectorsFormat.VERSION_CURRENT);
 
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter.java
@@ -195,8 +195,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter extends KnnVector
 
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets =
-          writeGraph(hnswGraph, hnswVectorIndex, Lucene99HnswVectorsFormat.VERSION_CURRENT);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 
       // Write metadata
@@ -285,8 +284,7 @@ public class LuceneAcceleratedHNSWBinaryQuantizedVectorsWriter extends KnnVector
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
 
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets =
-          writeGraph(hnswGraph, hnswVectorIndex, Lucene99HnswVectorsFormat.VERSION_CURRENT);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
 
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedCodec.java
@@ -25,7 +25,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedCodec extends FilterCodec {
   private KnnVectorsFormat format;
 
   public LuceneAcceleratedHNSWScalarQuantizedCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
   }
 
   public LuceneAcceleratedHNSWScalarQuantizedCodec(String name, Codec delegate) {
@@ -35,7 +35,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedCodec extends FilterCodec {
 
   public LuceneAcceleratedHNSWScalarQuantizedCodec(AcceleratedHNSWParams acceleratedHNSWParams)
       throws Exception {
-    this(NAME, LuceneProvider.getCodec("101"));
+    this(NAME, LuceneProvider.getCodec("104"));
     initializeFormat(acceleratedHNSWParams);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedCodec.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedCodec.java
@@ -25,7 +25,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedCodec extends FilterCodec {
   private KnnVectorsFormat format;
 
   public LuceneAcceleratedHNSWScalarQuantizedCodec() throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
   }
 
   public LuceneAcceleratedHNSWScalarQuantizedCodec(String name, Codec delegate) {
@@ -35,7 +35,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedCodec extends FilterCodec {
 
   public LuceneAcceleratedHNSWScalarQuantizedCodec(AcceleratedHNSWParams acceleratedHNSWParams)
       throws Exception {
-    this(NAME, LuceneProvider.getCodec("104"));
+    this(NAME, LuceneProvider.getLucene104Codec());
     initializeFormat(acceleratedHNSWParams);
   }
 

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsFormat.java
@@ -33,10 +33,10 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsFormat extends KnnVector
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance("104");
       FLAT_VECTORS_FORMAT = LUCENE_PROVIDER.getLuceneScalarQuantizedVectorsFormatInstance();
     } catch (Exception e) {
-      throw new ExceptionInInitializerError(e.getMessage());
+      throw new ExceptionInInitializerError(e);
     }
   }
 
@@ -75,7 +75,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsFormat extends KnnVector
         // Fallback to Lucene's Lucene99HnswScalarQuantizedVectorsFormat
         log.warning(
             "GPU based indexing not supported, falling back to using the"
-                + " Lucene99HnswScalarQuantizedVectorsFormat");
+                + " Lucene104HnswScalarQuantizedVectorsFormat");
         KnnVectorsFormat fallbackFormat =
             LUCENE_PROVIDER.getLuceneHnswScalarQuantizedVectorsFormatInstance(
                 acceleratedHNSWParams.getBeamWidth(), acceleratedHNSWParams.getMaxConn());

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsFormat.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsFormat.java
@@ -33,7 +33,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsFormat extends KnnVector
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("104");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_CODEC_LINE);
       FLAT_VECTORS_FORMAT = LUCENE_PROVIDER.getLuceneScalarQuantizedVectorsFormatInstance();
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e);
@@ -72,7 +72,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsFormat extends KnnVector
           state, acceleratedHNSWParams, flatWriter);
     } else {
       try {
-        // Fallback to Lucene's Lucene99HnswScalarQuantizedVectorsFormat
+        // Lucene 10.4 core Lucene104HnswScalarQuantizedVectorsFormat
         log.warning(
             "GPU based indexing not supported, falling back to using the"
                 + " Lucene104HnswScalarQuantizedVectorsFormat");

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
@@ -73,7 +73,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
 
   static {
     try {
-      LUCENE_PROVIDER = LuceneProvider.getInstance("99");
+      LUCENE_PROVIDER = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
       VERSION_CURRENT = LUCENE_PROVIDER.getStaticIntParam("VERSION_CURRENT");
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e.getMessage());
@@ -221,7 +221,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
 
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
 
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 
@@ -309,7 +309,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
 
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 
       // Write metadata

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneAcceleratedHNSWScalarQuantizedVectorsWriter.java
@@ -221,7 +221,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
 
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
 
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 
@@ -309,7 +309,7 @@ public class LuceneAcceleratedHNSWScalarQuantizedVectorsWriter extends KnnVector
 
       long vectorIndexOffset = hnswVectorIndex.getFilePointer();
       // Write the graph to the vector index
-      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex);
+      int[][] graphLevelNodeOffsets = writeGraph(hnswGraph, hnswVectorIndex, VERSION_CURRENT);
       long vectorIndexLength = hnswVectorIndex.getFilePointer() - vectorIndexOffset;
 
       // Write metadata

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneProvider.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneProvider.java
@@ -9,9 +9,12 @@ import java.lang.invoke.VarHandle;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.hnsw.FlatVectorsFormat;
@@ -79,7 +82,7 @@ public class LuceneProvider {
   private static String luceneCodec = BASE + codecs + "Lucene<version>Codec";
   private static String luceneCodecFallback = BASE + fallbackCodecs + "Lucene<version>Codec";
 
-  private static LuceneProvider instance;
+  private static final Map<String, LuceneProvider> INSTANCES = new ConcurrentHashMap<>();
 
   private static MethodHandles.Lookup lookup = MethodHandles.lookup();
 
@@ -93,29 +96,35 @@ public class LuceneProvider {
   private Class<?> hnswScalarQuantizedVectorsFormat;
 
   public static LuceneProvider getInstance(String version) throws ClassNotFoundException {
-    if (instance == null) {
-      instance = new LuceneProvider(version);
+    try {
+      return INSTANCES.computeIfAbsent(version, LuceneProvider::newInstanceUnchecked);
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof ClassNotFoundException cnfe) {
+        throw cnfe;
+      }
+      throw e;
     }
-    return instance;
+  }
+
+  private static LuceneProvider newInstanceUnchecked(String version) {
+    try {
+      return new LuceneProvider(version);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private LuceneProvider(String version) throws ClassNotFoundException {
+    // Lucene 10.4 still stores float HNSW and the default FlatVectorsFormat under lucene99; there
+    // is no lucene104 Lucene104FlatVectorsFormat / Lucene104HnswVectorsFormat in lucene-core.
     flatVectorsFormat =
-        loadClass(
-            setVersion(luceneFlatVectorsFormat, version),
-            setVersion(luceneFlatVectorsFormatFallback, version));
+        loadVectorFamilyClass(version, luceneFlatVectorsFormat, luceneFlatVectorsFormatFallback);
     hnswVectorsFormat =
-        loadClass(
-            setVersion(luceneHnswVectorsFormat, version),
-            setVersion(luceneHnswVectorsFormatFallback, version));
+        loadVectorFamilyClass(version, luceneHnswVectorsFormat, luceneHnswVectorsFormatFallback);
     hnswVectorsReader =
-        loadClass(
-            setVersion(luceneHnswVectorsReader, version),
-            setVersion(luceneHnswVectorsReaderFallback, version));
+        loadVectorFamilyClass(version, luceneHnswVectorsReader, luceneHnswVectorsReaderFallback);
     hnswVectorsWriter =
-        loadClass(
-            setVersion(luceneHnswVectorsWriter, version),
-            setVersion(luceneHnswVectorsWriterFallback, version));
+        loadVectorFamilyClass(version, luceneHnswVectorsWriter, luceneHnswVectorsWriterFallback);
     scalarQuantizedVectorsFormat =
         loadClass(
             setVersion(luceneScalarQuantizedVectorsFormat, version),
@@ -126,7 +135,8 @@ public class LuceneProvider {
             setVersion(luceneHnswScalarQuantizedVectorsFormat, version),
             setVersion(luceneHnswScalarQuantizedVectorsFormatFallback, version));
 
-    // TODO: Find a better way if possible, but as a separate initiative.
+    // Binary-quantized storage lives under lucene102 packages. Lucene 10.4 keeps these types in
+    // backward-codecs only; there is no lucene104 BinaryQuantizedVectorsFormat.
     if ("102".equals(version)) {
       binaryQuantizedVectorsFormat =
           loadClass(
@@ -136,11 +146,30 @@ public class LuceneProvider {
           loadClass(
               setVersion(luceneHnswBinaryQuantizedVectorsFormat, version),
               setVersion(luceneHnswBinaryQuantizedVectorsFormatFallback, version));
+    } else if ("104".equals(version)) {
+      final String lucene102BinaryFlat =
+          BASE + "backward_codecs.lucene102.Lucene102BinaryQuantizedVectorsFormat";
+      final String lucene102HnswBinary =
+          BASE + "backward_codecs.lucene102.Lucene102HnswBinaryQuantizedVectorsFormat";
+      binaryQuantizedVectorsFormat = loadClass(lucene102BinaryFlat, lucene102BinaryFlat);
+      hnswBinaryQuantizedVectorsFormat = loadClass(lucene102HnswBinary, lucene102HnswBinary);
     }
   }
 
   private static String setVersion(String pkg, String version) {
     return pkg.replaceAll("<version>", version);
+  }
+
+  private Class<?> loadVectorFamilyClass(String version, String primaryTpl, String fallbackTpl)
+      throws ClassNotFoundException {
+    try {
+      return loadClass(setVersion(primaryTpl, version), setVersion(fallbackTpl, version));
+    } catch (ClassNotFoundException e) {
+      if ("99".equals(version)) {
+        throw e;
+      }
+      return loadClass(setVersion(primaryTpl, "99"), setVersion(fallbackTpl, "99"));
+    }
   }
 
   private static Class<?> loadClass(String defaultClassName, String fallbackClassName)
@@ -258,17 +287,26 @@ public class LuceneProvider {
     }
   }
 
-  public FlatVectorsFormat getLuceneHnswBinaryQuantizedVectorsFormatInstance(
+  public KnnVectorsFormat getLuceneHnswBinaryQuantizedVectorsFormatInstance(
       int maxConn, int beamWidth) throws Exception {
     try {
-      Constructor<?> luceneHnswBinaryQuantizedVectorsFormatConstructor =
+      Constructor<?> ctor =
           hnswBinaryQuantizedVectorsFormat.getConstructor(Integer.TYPE, Integer.TYPE);
-      return (FlatVectorsFormat)
-          luceneHnswBinaryQuantizedVectorsFormatConstructor.newInstance(maxConn, beamWidth);
+      return (KnnVectorsFormat) ctor.newInstance(maxConn, beamWidth);
+    } catch (NoSuchMethodException ignored) {
+      try {
+        Constructor<?> ctor = hnswBinaryQuantizedVectorsFormat.getConstructor();
+        return (KnnVectorsFormat) ctor.newInstance();
+      } catch (Exception e) {
+        log.log(
+            Level.SEVERE,
+            "Unable to initialize LuceneHnswBinaryQuantizedVectorsFormat: " + e.getMessage());
+        throw e;
+      }
     } catch (Exception e) {
       log.log(
           Level.SEVERE,
-          "Unable to initialize LuceneBinaryQuantizedVectorsFormat: " + e.getMessage());
+          "Unable to initialize LuceneHnswBinaryQuantizedVectorsFormat: " + e.getMessage());
       throw e;
     }
   }
@@ -286,12 +324,12 @@ public class LuceneProvider {
     }
   }
 
-  public FlatVectorsFormat getLuceneHnswScalarQuantizedVectorsFormatInstance(
+  public KnnVectorsFormat getLuceneHnswScalarQuantizedVectorsFormatInstance(
       int beamWidth, int maxConn) throws Exception {
     try {
       Constructor<?> luceneHnswScalarQuantizedVectorsFormatConstructor =
           hnswScalarQuantizedVectorsFormat.getConstructor(Integer.TYPE, Integer.TYPE);
-      return (FlatVectorsFormat)
+      return (KnnVectorsFormat)
           luceneHnswScalarQuantizedVectorsFormatConstructor.newInstance(beamWidth, maxConn);
     } catch (Exception e) {
       log.log(

--- a/src/main/java/com/nvidia/cuvs/lucene/LuceneProvider.java
+++ b/src/main/java/com/nvidia/cuvs/lucene/LuceneProvider.java
@@ -27,13 +27,24 @@ import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.TaskExecutor;
 
 /**
- * Dynamically loads Lucene format, reader, and writer classes with a fallback mechanism.
+ * Reflectively loads Lucene codec and vector format classes. This module targets <strong>Apache
+ * Lucene 10.4.x</strong> only ({@link #LUCENE_CODEC_LINE} / {@link #LUCENE_FLOAT_HNSW_LINE}).
  *
  * @since 25.12
  */
 public class LuceneProvider {
 
   static final Logger log = Logger.getLogger(LuceneProvider.class.getName());
+
+  /** Lucene {@code Codec} SPI line id for the Lucene 10.4 core delegate (e.g. {@code Lucene104Codec}). */
+  public static final String LUCENE_CODEC_LINE = "104";
+
+  /**
+   * Lucene 10.4 keeps float HNSW and the default {@code FlatVectorsFormat} under {@code
+   * codecs.lucene99} (there is no {@code Lucene104FlatVectorsFormat} / {@code Lucene104HnswVectors*}
+   * in {@code lucene-core}).
+   */
+  public static final String LUCENE_FLOAT_HNSW_LINE = "99";
 
   private static final String BASE = "org.apache.lucene.";
   private static String codecs = "codecs.lucene<version>.";
@@ -58,16 +69,6 @@ public class LuceneProvider {
       BASE + codecs + "Lucene<version>HnswVectorsWriter";
   private static String luceneHnswVectorsWriterFallback =
       BASE + fallbackCodecs + "Lucene<version>HnswVectorsWriter";
-
-  private static String luceneBinaryQuantizedVectorsFormat =
-      BASE + codecs + "Lucene<version>BinaryQuantizedVectorsFormat";
-  private static String luceneBinaryQuantizedVectorsFormatFallback =
-      BASE + fallbackCodecs + "Lucene<version>BinaryQuantizedVectorsFormat";
-
-  private static String luceneHnswBinaryQuantizedVectorsFormat =
-      BASE + codecs + "Lucene<version>HnswBinaryQuantizedVectorsFormat";
-  private static String luceneHnswBinaryQuantizedVectorsFormatFallback =
-      BASE + fallbackCodecs + "Lucene<version>HnswBinaryQuantizedVectorsFormat";
 
   private static String luceneScalarQuantizedVectorsFormat =
       BASE + codecs + "Lucene<version>ScalarQuantizedVectorsFormat";
@@ -115,16 +116,24 @@ public class LuceneProvider {
   }
 
   private LuceneProvider(String version) throws ClassNotFoundException {
-    // Lucene 10.4 still stores float HNSW and the default FlatVectorsFormat under lucene99; there
-    // is no lucene104 Lucene104FlatVectorsFormat / Lucene104HnswVectorsFormat in lucene-core.
+    final String floatHnswPackageLine =
+        LUCENE_CODEC_LINE.equals(version) ? LUCENE_FLOAT_HNSW_LINE : version;
     flatVectorsFormat =
-        loadVectorFamilyClass(version, luceneFlatVectorsFormat, luceneFlatVectorsFormatFallback);
+        loadClass(
+            setVersion(luceneFlatVectorsFormat, floatHnswPackageLine),
+            setVersion(luceneFlatVectorsFormatFallback, floatHnswPackageLine));
     hnswVectorsFormat =
-        loadVectorFamilyClass(version, luceneHnswVectorsFormat, luceneHnswVectorsFormatFallback);
+        loadClass(
+            setVersion(luceneHnswVectorsFormat, floatHnswPackageLine),
+            setVersion(luceneHnswVectorsFormatFallback, floatHnswPackageLine));
     hnswVectorsReader =
-        loadVectorFamilyClass(version, luceneHnswVectorsReader, luceneHnswVectorsReaderFallback);
+        loadClass(
+            setVersion(luceneHnswVectorsReader, floatHnswPackageLine),
+            setVersion(luceneHnswVectorsReaderFallback, floatHnswPackageLine));
     hnswVectorsWriter =
-        loadVectorFamilyClass(version, luceneHnswVectorsWriter, luceneHnswVectorsWriterFallback);
+        loadClass(
+            setVersion(luceneHnswVectorsWriter, floatHnswPackageLine),
+            setVersion(luceneHnswVectorsWriterFallback, floatHnswPackageLine));
     scalarQuantizedVectorsFormat =
         loadClass(
             setVersion(luceneScalarQuantizedVectorsFormat, version),
@@ -135,18 +144,7 @@ public class LuceneProvider {
             setVersion(luceneHnswScalarQuantizedVectorsFormat, version),
             setVersion(luceneHnswScalarQuantizedVectorsFormatFallback, version));
 
-    // Binary-quantized storage lives under lucene102 packages. Lucene 10.4 keeps these types in
-    // backward-codecs only; there is no lucene104 BinaryQuantizedVectorsFormat.
-    if ("102".equals(version)) {
-      binaryQuantizedVectorsFormat =
-          loadClass(
-              setVersion(luceneBinaryQuantizedVectorsFormat, version),
-              setVersion(luceneBinaryQuantizedVectorsFormatFallback, version));
-      hnswBinaryQuantizedVectorsFormat =
-          loadClass(
-              setVersion(luceneHnswBinaryQuantizedVectorsFormat, version),
-              setVersion(luceneHnswBinaryQuantizedVectorsFormatFallback, version));
-    } else if ("104".equals(version)) {
+    if (LUCENE_CODEC_LINE.equals(version)) {
       final String lucene102BinaryFlat =
           BASE + "backward_codecs.lucene102.Lucene102BinaryQuantizedVectorsFormat";
       final String lucene102HnswBinary =
@@ -158,18 +156,6 @@ public class LuceneProvider {
 
   private static String setVersion(String pkg, String version) {
     return pkg.replaceAll("<version>", version);
-  }
-
-  private Class<?> loadVectorFamilyClass(String version, String primaryTpl, String fallbackTpl)
-      throws ClassNotFoundException {
-    try {
-      return loadClass(setVersion(primaryTpl, version), setVersion(fallbackTpl, version));
-    } catch (ClassNotFoundException e) {
-      if ("99".equals(version)) {
-        throw e;
-      }
-      return loadClass(setVersion(primaryTpl, "99"), setVersion(fallbackTpl, "99"));
-    }
   }
 
   private static Class<?> loadClass(String defaultClassName, String fallbackClassName)
@@ -200,6 +186,18 @@ public class LuceneProvider {
         loadClass(setVersion(luceneCodec, version), setVersion(luceneCodecFallback, version));
     Constructor<?> codecClassConstructor = codecClass.getConstructor();
     return (Codec) codecClassConstructor.newInstance();
+  }
+
+  /** Lucene 10.4 default codec delegate ({@link #LUCENE_CODEC_LINE}). */
+  public static Codec getLucene104Codec()
+      throws ClassNotFoundException,
+          NoSuchMethodException,
+          SecurityException,
+          InstantiationException,
+          IllegalAccessException,
+          IllegalArgumentException,
+          InvocationTargetException {
+    return getCodec(LUCENE_CODEC_LINE);
   }
 
   public FlatVectorsFormat getLuceneFlatVectorsFormatInstance(FlatVectorsScorer scorer)
@@ -287,22 +285,11 @@ public class LuceneProvider {
     }
   }
 
-  public KnnVectorsFormat getLuceneHnswBinaryQuantizedVectorsFormatInstance(
-      int maxConn, int beamWidth) throws Exception {
+  /** Lucene 10.4 {@code Lucene102HnswBinaryQuantizedVectorsFormat} (backward-codecs) no-arg ctor. */
+  public KnnVectorsFormat getLuceneHnswBinaryQuantizedVectorsFormatInstance() throws Exception {
     try {
-      Constructor<?> ctor =
-          hnswBinaryQuantizedVectorsFormat.getConstructor(Integer.TYPE, Integer.TYPE);
-      return (KnnVectorsFormat) ctor.newInstance(maxConn, beamWidth);
-    } catch (NoSuchMethodException ignored) {
-      try {
-        Constructor<?> ctor = hnswBinaryQuantizedVectorsFormat.getConstructor();
-        return (KnnVectorsFormat) ctor.newInstance();
-      } catch (Exception e) {
-        log.log(
-            Level.SEVERE,
-            "Unable to initialize LuceneHnswBinaryQuantizedVectorsFormat: " + e.getMessage());
-        throw e;
-      }
+      Constructor<?> ctor = hnswBinaryQuantizedVectorsFormat.getConstructor();
+      return (KnnVectorsFormat) ctor.newInstance();
     } catch (Exception e) {
       log.log(
           Level.SEVERE,

--- a/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
+++ b/src/main/resources/META-INF/services/org.apache.lucene.codecs.KnnVectorsFormat
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat
-org.apache.lucene.codecs.lucene99.Lucene99HnswScalarQuantizedVectorsFormat
 com.nvidia.cuvs.lucene.CuVS2510GPUVectorsFormat
 com.nvidia.cuvs.lucene.Lucene99AcceleratedHNSWVectorsFormat
 com.nvidia.cuvs.lucene.LuceneAcceleratedHNSWBinaryQuantizedVectorsFormat

--- a/src/test/java/com/nvidia/cuvs/lucene/TestBackCompat.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestBackCompat.java
@@ -21,8 +21,8 @@ public class TestBackCompat {
 
   @Test
   public void testFallback() throws Exception {
-    // Lucene99Codec exists in the org.apache.lucene.backward_codecs.lucene99
-    Codec c = LuceneProvider.getCodec("99");
+    // Lucene 10.4 backward-codecs: Lucene99Codec (SPI line id matches float/HNSW package line "99")
+    Codec c = LuceneProvider.getCodec(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
     assertEquals(c.getName(), "Lucene99");
   }
 
@@ -33,7 +33,7 @@ public class TestBackCompat {
 
   @Test
   public void testExistingComponents() throws Exception {
-    LuceneProvider provider = LuceneProvider.getInstance("99");
+    LuceneProvider provider = LuceneProvider.getInstance(LuceneProvider.LUCENE_FLOAT_HNSW_LINE);
     assertTrue(provider.getLuceneFlatVectorsFormatInstance(null) instanceof FlatVectorsFormat);
     // Lucene 10.4: Lucene99HnswVectorsFormat.VERSION_CURRENT == 1 (GroupVarInt graph encoding).
     assertEquals(1, provider.getStaticIntParam("VERSION_CURRENT"));

--- a/src/test/java/com/nvidia/cuvs/lucene/TestBackCompat.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestBackCompat.java
@@ -35,7 +35,8 @@ public class TestBackCompat {
   public void testExistingComponents() throws Exception {
     LuceneProvider provider = LuceneProvider.getInstance("99");
     assertTrue(provider.getLuceneFlatVectorsFormatInstance(null) instanceof FlatVectorsFormat);
-    assertEquals(provider.getStaticIntParam("VERSION_CURRENT"), 0);
+    // Lucene 10.4: Lucene99HnswVectorsFormat.VERSION_CURRENT == 1 (GroupVarInt graph encoding).
+    assertEquals(1, provider.getStaticIntParam("VERSION_CURRENT"));
     assertNotEquals(provider.getSimilarityFunctions().size(), 0);
   }
 }

--- a/src/test/java/com/nvidia/cuvs/lucene/TestCagraToHnswSerializationAndSearch.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestCagraToHnswSerializationAndSearch.java
@@ -194,6 +194,10 @@ public class TestCagraToHnswSerializationAndSearch extends LuceneTestCase {
 
   @After
   public void afterTest() throws Exception {
+    // If setup was skipped (e.g. cuVS not supported), @Before didn't run and indexDirPath is null.
+    if (indexDirPath == null) {
+      return;
+    }
     File indexDirPathFile = indexDirPath.toFile();
     if (indexDirPathFile.exists() && indexDirPathFile.isDirectory()) {
       FileUtils.deleteDirectory(indexDirPathFile);

--- a/src/test/java/com/nvidia/cuvs/lucene/TestCagraToHnswSerializationAndSearchWithFallbackWriter.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestCagraToHnswSerializationAndSearchWithFallbackWriter.java
@@ -165,6 +165,11 @@ public class TestCagraToHnswSerializationAndSearchWithFallbackWriter extends Luc
   public static void afterClass() throws Exception {
     // Reset resources for other tests to work
     setCuVSResourcesInstance(cuVSResourcesOrNull());
+    // If setup was skipped (e.g. cuVS not supported), @BeforeClass didn't run and indexDirPath is
+    // null.
+    if (indexDirPath == null) {
+      return;
+    }
     File indexDirPathFile = indexDirPath.toFile();
     if (indexDirPathFile.exists() && indexDirPathFile.isDirectory()) {
       FileUtils.deleteDirectory(indexDirPathFile);

--- a/src/test/java/com/nvidia/cuvs/lucene/TestCuVSVectorsFormat.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestCuVSVectorsFormat.java
@@ -7,6 +7,7 @@ package com.nvidia.cuvs.lucene;
 import static com.nvidia.cuvs.lucene.ThreadLocalCuVSResourcesProvider.isSupported;
 import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
 
+import java.io.IOException;
 import java.util.List;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.document.Document;
@@ -19,6 +20,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
 import org.apache.lucene.tests.util.LuceneTestCase.SuppressSysoutChecks;
@@ -37,6 +39,17 @@ public class TestCuVSVectorsFormat extends BaseKnnVectorsFormatTestCase {
   @Override
   protected Codec getCodec() {
     return TestUtil.alwaysKnnVectorsFormat(new CuVS2510GPUVectorsFormat());
+  }
+
+  @Override
+  protected boolean supportsFloatVectorFallback() {
+    return false;
+  }
+
+  @Override
+  protected void assertOffHeapByteSize(LeafReader r, String fieldName) throws IOException {
+    // CuVS reader uses native/GPU memory; off-heap accounting is not aligned with base test
+    // expectations (getOffHeapByteSize keys/values). Skip to avoid false failures.
   }
 
   public void testMergeTwoSegsWithASingleDocPerSeg() throws Exception {
@@ -111,7 +124,9 @@ public class TestCuVSVectorsFormat extends BaseKnnVectorsFormatTestCase {
         assertArrayEquals(f2[1], values.vectorValue(1), 0.0f);
 
         // opportunistically check boundary condition - search with a 0 topK
-        var topDocs = r.searchNearestVectors("f1", randomVector(384), 0, null, 10);
+        var topDocs =
+            r.searchNearestVectors(
+                "f1", randomVector(384), 0, AcceptDocs.fromLiveDocs(null, r.maxDoc()), 10);
         assertEquals(0, topDocs.scoreDocs.length);
         assertEquals(0, topDocs.totalHits.value());
       }

--- a/src/test/java/com/nvidia/cuvs/lucene/TestLucene99AcceleratedHNSWVectorsFormat.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestLucene99AcceleratedHNSWVectorsFormat.java
@@ -39,6 +39,11 @@ public class TestLucene99AcceleratedHNSWVectorsFormat extends BaseKnnVectorsForm
     return TestUtil.alwaysKnnVectorsFormat(new Lucene99AcceleratedHNSWVectorsFormat());
   }
 
+  @Override
+  protected boolean supportsFloatVectorFallback() {
+    return false;
+  }
+
   public void testMergeTwoSegsWithASingleDocPerSeg() throws Exception {
     float[][] f = new float[][] {randomVector(384), randomVector(384)};
     try (Directory dir = newDirectory();

--- a/src/test/java/com/nvidia/cuvs/lucene/TestQuantizedVectorsFormats.java
+++ b/src/test/java/com/nvidia/cuvs/lucene/TestQuantizedVectorsFormats.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
@@ -63,6 +64,11 @@ public class TestQuantizedVectorsFormats extends BaseKnnVectorsFormatTestCase {
   protected Codec getCodec() {
     log.log(Level.FINE, "Running tests for: " + knnVectorsFormat.getName());
     return TestUtil.alwaysKnnVectorsFormat(knnVectorsFormat);
+  }
+
+  @Override
+  protected boolean supportsFloatVectorFallback() {
+    return false;
   }
 
   public void testMergeTwoSegsWithASingleDocPerSeg() throws Exception {
@@ -174,7 +180,8 @@ public class TestQuantizedVectorsFormats extends BaseKnnVectorsFormatTestCase {
         assertEquals(R, values.size());
 
         float[] queryVector = randomVector(D);
-        var topDocs = r.searchNearestVectors(F, queryVector, 2, null, 10);
+        AcceptDocs acceptAll = AcceptDocs.fromLiveDocs(null, r.maxDoc());
+        var topDocs = r.searchNearestVectors(F, queryVector, 2, acceptAll, 10);
         assertTrue("Should return at least one result", topDocs.scoreDocs.length > 0);
         assertTrue("Scores should be non-negative", topDocs.scoreDocs[0].score >= 0);
       }


### PR DESCRIPTION
- Move the project to Lucene 10.4.0 (poms + examples) and line up cuvs-java with the 26.04 natives
- Point our codec wrappers at Lucene104
- Update GPU vector search for Lucene’s AcceptDocs API 
- use GroupVarInt
- Updated tests