### PR TITLE
Build and test with CUDA 13.3.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ permissions: {}
 jobs:
   java-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ permissions: {}
 jobs:
   java-build:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.2.0'
+          - '13.3.0'
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - conda-java-tests
       - telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -54,7 +54,7 @@ jobs:
   changed-files:
     needs: telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@cuda-13.3.0
     with:
       files_yaml: |
         test_java:
@@ -71,7 +71,7 @@ jobs:
   checks:
     needs: telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.3.0
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
@@ -84,7 +84,7 @@ jobs:
   conda-java-tests:
     needs: [changed-files, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
@@ -93,7 +93,7 @@ jobs:
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.2.0'
+          - '13.3.0'
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - conda-java-tests
       - telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -54,7 +54,7 @@ jobs:
   changed-files:
     needs: telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@main
     with:
       files_yaml: |
         test_java:
@@ -71,7 +71,7 @@ jobs:
   checks:
     needs: telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
@@ -84,7 +84,7 @@ jobs:
   conda-java-tests:
     needs: [changed-files, checks]
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
     # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
     # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,13 +24,13 @@ permissions: {}
 jobs:
   conda-java-tests:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     strategy:
       fail-fast: false
       matrix:
         cuda_version:
           - '12.9.1'
-          - '13.2.0'
+          - '13.3.0'
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   conda-java-tests:
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     strategy:
       fail-fast: false
       matrix:

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -10,9 +10,9 @@ dependencies:
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-version=13.2
+- cuda-version=13.3
 - cxx-compiler
-- gcc_linux-64=14.*
+- gcc_linux-aarch64=14.*
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev
@@ -21,5 +21,5 @@ dependencies:
 - maven
 - ninja
 - openjdk=22.*
-- sysroot_linux-64==2.28
-name: all_cuda-132_arch-x86_64
+- sysroot_linux-aarch64==2.28
+name: all_cuda-133_arch-aarch64

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -10,9 +10,9 @@ dependencies:
 - cuda-nvcc
 - cuda-nvtx-dev
 - cuda-profiler-api
-- cuda-version=13.2
+- cuda-version=13.3
 - cxx-compiler
-- gcc_linux-aarch64=14.*
+- gcc_linux-64=14.*
 - libcublas-dev
 - libcurand-dev
 - libcusolver-dev
@@ -21,5 +21,5 @@ dependencies:
 - maven
 - ninja
 - openjdk=22.*
-- sysroot_linux-aarch64==2.28
-name: all_cuda-132_arch-aarch64
+- sysroot_linux-64==2.28
+name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Dependency list for https://github.com/rapidsai/dependency-file-generator

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,7 +6,7 @@ files:
   all:
     output: conda
     matrix:
-      cuda: ["12.9", "13.2"]
+      cuda: ["12.9", "13.3"]
       arch: [x86_64, aarch64]
     includes:
       - cuda
@@ -67,6 +67,10 @@ dependencies:
               cuda: "13.2"
             packages:
               - cuda-version=13.2
+          - matrix:
+              cuda: "13.3"
+            packages:
+              - cuda-version=13.3
   cuda:
     common:
       - output_types: [conda]

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ cd ..
 
 Then do:
 ```sh
-docker run --rm --gpus all --pull=always --volume $PWD:$PWD --workdir $PWD -it rapidsai/ci-conda:26.08-cuda13.2.0-ubuntu24.04-py3.13
+docker run --rm --gpus all --pull=always --volume $PWD:$PWD --workdir $PWD -it rapidsai/ci-conda:26.08-cuda13.3.0-ubuntu24.04-py3.13
 ```
 
 Inside the docker container (and in the `cuvs-lucene's` root directory) do:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/286

* uses CUDA 13.3.0 to build and test
* updates to CUDA 13.3.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.3.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/574

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.

