### PR TITLE
use GCS mirror for Maven, fix benchmarks version, other small changes

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,6 @@
+-e
+-B
+-Daether.connector.basic.downstreamThreads=1
+-Daether.transport.http.retryHandler.count=5
+-Daether.transport.http.retryHandler.interval=10000
+-Dmaven.wagon.http.retryHandler.count=5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
@@ -9,8 +9,9 @@ repos:
               - id: trailing-whitespace
               - id: end-of-file-fixer
               - id: check-symlinks
+              - id: check-xml
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.4.2
+        rev: v1.5.1
         hooks:
           - id: verify-copyright
             name: verify-copyright
@@ -24,7 +25,7 @@ repos:
                   dependencies[.]yaml$|
                   ^[.]pre-commit-config[.]yaml$
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.20.2
+        rev: v1.21.0
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean", "--warn-all", "--strict"]
@@ -33,6 +34,6 @@ repos:
         hooks:
           - id: shellcheck
       - repo: https://github.com/zizmorcore/zizmor-pre-commit
-        rev: v1.24.1
+        rev: v1.26.1
         hooks:
           - id: zizmor

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This library provides a new [KnnVectorFormat](https://lucene.apache.org/core/10_
 ## Building
 
 ### Prerequisites
+
 - [CUDA 12.0+](https://developer.nvidia.com/cuda-toolkit-archive),
 - [Maven 3.9.6+](https://maven.apache.org/download.cgi),
 - [JDK 22](https://jdk.java.net/archive/)
@@ -16,9 +17,11 @@ This library provides a new [KnnVectorFormat](https://lucene.apache.org/core/10_
 ```sh
 mvn clean compile package
 ```
+
 The artifacts would be built and available in the target / folder.
 
 ### Running Tests
+
 ```sh
 export LD_LIBRARY_PATH={ PATH TO YOUR LOCAL libcuvs_c.so }:$LD_LIBRARY_PATH && mvn clean test
 ```

--- a/bench/pom.xml
+++ b/bench/pom.xml
@@ -11,10 +11,64 @@
 
     <groupId>com.nvidia.cuvs.lucene.benchmarks</groupId>
     <artifactId>cuvs-lucene-benchmarks</artifactId>
-    <!--CUVS_JAVA#VERSION_UPDATE_MARKER_START--><version>26.02.0</version><!--CUVS_JAVA#VERSION_UPDATE_MARKER_END-->
+    <!--CUVS_LUCENE#VERSION_UPDATE_MARKER_START--><version>26.08.0</version><!--CUVS_LUCENE#VERSION_UPDATE_MARKER_END-->
     <packaging>jar</packaging>
 
     <name>cuvs-lucene-benchmarks</name>
+
+    <repositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <repository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <pluginRepository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <pluginRepository>
+            <id>central</id>
+            <name>Maven Plugin Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This maven project contains basic examples that showcase how `cuvs-lucene` can be used.
 
 ## Prerequisites
+
 - [Docker](https://www.docker.com/)
 - [Nvidia Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 - A machine with an Nvidia GPU
@@ -10,26 +11,31 @@ This maven project contains basic examples that showcase how `cuvs-lucene` can b
 ## Steps
 
 If you are currently in this directory (and to be in the `cuvs-lucene's` root directory) do:
+
 ```sh
 cd ..
 ```
 
 Then do:
+
 ```sh
 docker run --rm --gpus all --pull=always --volume $PWD:$PWD --workdir $PWD -it rapidsai/ci-conda:26.08-cuda13.2.0-ubuntu24.04-py3.13
 ```
 
 Inside the docker container (and in the `cuvs-lucene's` root directory) do:
+
 ```sh
 ./ci/build_java.sh && conda activate java && cd examples
 ```
 
 To run Accelerated HNSW example do:
+
 ```sh
 mvn clean install && java -Djava.util.logging.config.file=src/main/resources/logging.properties -cp target/examples-26.08.0-jar-with-merged-services.jar com.nvidia.cuvs.lucene.examples.AcceleratedHnswExample
 ```
 
 To run the Index and Search on GPU example do:
+
 ```sh
 mvn clean install && java -Djava.util.logging.config.file=src/main/resources/logging.properties -cp target/examples-26.08.0-jar-with-merged-services.jar com.nvidia.cuvs.lucene.examples.IndexAndSearchonGPUExample
 ```

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,10 +21,59 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-    </dependencies>
-  </dependencyManagement>
+    <repositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <repository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <pluginRepository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <pluginRepository>
+            <id>central</id>
+            <name>Maven Plugin Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,60 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
+    <repositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <repository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <!-- Prefer Google Cloud mirror, which has higher rate limits -->
+        <pluginRepository>
+            <id>gcs-maven-central-mirror</id>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <!-- Fall back to Maven upstream for packages not found in GCS mirror -->
+        <pluginRepository>
+            <id>central</id>
+            <name>Maven Plugin Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
   <dependencies>
     <dependency>
         <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
Fixes #145 

Contributes to https://github.com/rapidsai/build-planning/issues/297

The root cause of #145 appears to be that we were getting rate-limited by Maven Central. Similar to https://github.com/NVIDIA/cuvs/pull/2253, this proposes fixing that by using the same read-only Maven mirror that Apache Orc, Lucene, Spark and others use in their builds (https://storage-download.googleapis.com/maven-central/index.html).

Other changes:

* fixes microbenchmarks version (was still 26.02 because it used the cuVS pattern for version replacement)
* adding default `mvn` options to request packages more slowly and wait longer between retries
* updating all `pre-commit` hooks w/ `pre-commit autoupdate`
* adding `check-xml` hook to validate that `pom.xml` are valid XML docs
* reformatting READMEs per https://yihui.org/en/2021/06/markdown-breath/