### PR TITLE
Update CODEOWNERS team names for rapidsai->NVIDIA migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,23 @@
 # default group
 # (will be overridden by more specific matches below)
-*                        @rapidsai/lucene-cuvs-write
+*                        @NVIDIA/cuvs-lucene-write
 
 # java code owners
-src/                     @rapidsai/cuvs-java-codeowners
+src/                     @NVIDIA/cuvs-java-codeowners
 
 # docs code owners
-LICENSE                  @rapidsai/cuvs-docs-codeowners
-/README.md               @rapidsai/cuvs-docs-codeowners
+LICENSE                  @NVIDIA/cuvs-docs-codeowners
+/README.md               @NVIDIA/cuvs-docs-codeowners
 
 # CI code owners
-/.github/                @rapidsai/ci-codeowners
-/ci/                     @rapidsai/ci-codeowners
+/.github/                @NVIDIA/adi-ci-codeowners
+/ci/                     @NVIDIA/adi-ci-codeowners
 
 # packaging code owners
-build.sh                 @rapidsai/packaging-codeowners
-dependencies.yaml        @rapidsai/packaging-codeowners
-pom.xml                  @rapidsai/cuvs-build-codeowners
-/.pre-commit-config.yaml @rapidsai/packaging-codeowners
+build.sh                 @NVIDIA/adi-packaging-codeowners
+dependencies.yaml        @NVIDIA/adi-packaging-codeowners
+pom.xml                  @NVIDIA/cuvs-build-codeowners
+/.pre-commit-config.yaml @NVIDIA/adi-packaging-codeowners
 
 # Ops code owners
-/SECURITY.md             @rapidsai/ops-codeowners
+/SECURITY.md             @NVIDIA/adi-ops-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,8 @@ repos:
                   meta[.]yaml$|
                   dependencies[.]yaml$|
                   ^[.]pre-commit-config[.]yaml$
+          - id: verify-codeowners
+            args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.21.0
         hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,9 @@ repos:
                   meta[.]yaml$|
                   dependencies[.]yaml$|
                   ^[.]pre-commit-config[.]yaml$
-          - id: verify-codeowners
-            args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
+          # TODO: Re-enable once verify-codeowners supports --org parameter
+          # - id: verify-codeowners
+          #   args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.21.0
         hooks:


### PR DESCRIPTION
XREF: https://github.com/rapidsai/build-infra/issues/371

CODEOWNER teams must be in the same org as the repo. Let's update them now that we've migrated to the NVIDIA org.

This is blocked on the next release of https://github.com/rapidsai/pre-commit-hooks