### PR TITLE
Bump rapidsai/pre-commit-hooks to v1.6.0, re-enable verify-codeowners

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
               - id: check-symlinks
               - id: check-xml
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.5.1
+        rev: v1.6.0
         hooks:
           - id: verify-copyright
             name: verify-copyright
@@ -24,9 +24,8 @@ repos:
                   meta[.]yaml$|
                   dependencies[.]yaml$|
                   ^[.]pre-commit-config[.]yaml$
-          # TODO: Re-enable once verify-codeowners supports --org parameter
-          # - id: verify-codeowners
-          #   args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
+          - id: verify-codeowners
+            args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.21.0
         hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
                   dependencies[.]yaml$|
                   ^[.]pre-commit-config[.]yaml$
           - id: verify-codeowners
-            args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
+            args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene, --no-cmake, --no-cpp, --no-packaging, --no-python]
       - repo: https://github.com/rapidsai/dependency-file-generator
         rev: v1.21.0
         hooks:


### PR DESCRIPTION
https://github.com/rapidsai/pre-commit-hooks/releases/tag/v1.6.0 now supports parameterizing the repo org for its `verify-codeowners` check.

Let's bump the version and re-enable the check.

XREF: https://github.com/rapidsai/build-infra/issues/371