### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -5,7 +5,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=3.30.4
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -5,7 +5,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=3.30.4
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -5,7 +5,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=3.30.4
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -5,7 +5,7 @@ channels:
 - conda-forge
 dependencies:
 - c-compiler
-- cmake>=3.30.4
+- cmake>=4.0,<4.4
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,7 +88,7 @@ dependencies:
       - output_types: conda
         packages:
           - c-compiler
-          - cmake>=3.30.4
+          - cmake>=4.0,<4.4
           - cuda-nvcc
           - maven
           - ninja


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
