### PR TITLE
Backport #179 Upgrade cuda 12.9.1 -> 12.9.2 to 26.08

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
+          - '12.9.2'
           - '13.3.0'
     with:
       build_type: ${{ inputs.build_type || 'branch' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
+          - '12.9.2'
           - '13.3.0'
     with:
       build_type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version:
-          - '12.9.1'
+          - '12.9.2'
           - '13.3.0'
     with:
       build_type: ${{ inputs.build_type }}


### PR DESCRIPTION
After the upgrade to 26.10 in #176, the build is failing due to the absence of the rapidsai/ci-conda:26.10-cuda12.9.1-ubuntu24.04-py3.13 image on Docker Hub. We also need to update the CUDA version to 12.9.2.
