### PR TITLE
Fix panama headers when RAPIDS_VERSION points to a PR branch

### DIFF
--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-pull-request/2345
+release/26.08

--- a/RAPIDS_BRANCH
+++ b/RAPIDS_BRANCH
@@ -1,1 +1,1 @@
-release/26.08
+pull-request/2345

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,13 @@ if hasArg --build-cuvs-java; then
     LD_LIBRARY_PATH="$LIBCUVS_DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
     export LD_LIBRARY_PATH
     echo "LD_LIBRARY_PATH is: $LD_LIBRARY_PATH"
+    # Point cmake to the PR artifact so find_package(cuvs) picks up its headers
+    # instead of the conda-installed ones, ensuring jextract generates correct
+    # Panama bindings for any new C API in the PR.
+    export CMAKE_PREFIX_PATH="$LIBCUVS_DIR"
+    # Uninstall the conda-installed libcuvs so it cannot shadow the PR artifact
+    # at runtime.
+    conda remove --yes --force-remove libcuvs
   fi
   ./build.sh "${CUVS_BUILD_TARGETS[@]}"
   popd

--- a/build.sh
+++ b/build.sh
@@ -31,29 +31,7 @@ if hasArg --build-cuvs-java; then
     pushd $CUVS_WORKDIR
   fi
 
-  # libcuvs comes from the conda packages, so normally only the java bindings have
-  # to be built. For a pull request, the conda packages do not contain the PR's
-  # changes, so CI downloads the pre-built libcuvs artifact from the PR's own CI run.
-  CUVS_BUILD_TARGETS=("java")
-  if hasArg --use-pr-libcuvs && [[ "$BRANCH" == pull-request/* ]]; then
-    PR_NUM="${BRANCH#pull-request/}"
-    echo "Downloading libcuvs conda artifact from cuvs PR #${PR_NUM}..."
-    LIBCUVS_CONDA_DIR=$(rapids-get-pr-artifact NVIDIA/cuvs "$PR_NUM" cpp conda)
-    LIBCUVS_DIR=$(rapids-extract-conda-files "$LIBCUVS_CONDA_DIR")
-    # The downloaded library has to take precedence over the one provided by the
-    # conda packages, both here and while running the java tests.
-    LD_LIBRARY_PATH="$LIBCUVS_DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-    export LD_LIBRARY_PATH
-    echo "LD_LIBRARY_PATH is: $LD_LIBRARY_PATH"
-    # Point cmake to the PR artifact so find_package(cuvs) picks up its headers
-    # instead of the conda-installed ones, ensuring jextract generates correct
-    # Panama bindings for any new C API in the PR.
-    export CMAKE_PREFIX_PATH="$LIBCUVS_DIR"
-    # Uninstall the conda-installed libcuvs so it cannot shadow the PR artifact
-    # at runtime.
-    conda remove --yes --force-remove libcuvs
-  fi
-  ./build.sh "${CUVS_BUILD_TARGETS[@]}"
+  ./build.sh java
   popd
 fi
 

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -65,6 +65,13 @@ fi
 # PR's changes, so download the pre-built libcuvs artifact from the PR's own CI run.
 BRANCH=$(cat "RAPIDS_BRANCH")
 if [[ "$BRANCH" == pull-request/* ]]; then
+  rapids-logger "Remove libcuvs from conda environment"
+  # Uninstall the conda libcuvs so the JVM's RPATH (which points to the conda
+  # env's lib dir) cannot find the old libcuvs_c.so ahead of the PR artifact.
+  set +u
+  conda remove --yes --force-remove libcuvs
+  set -u
+  # Download PR artifact
   PR_NUM="${BRANCH#pull-request/}"
   rapids-logger "Downloading libcuvs conda artifact from cuvs PR #${PR_NUM}"
   LIBCUVS_CONDA_DIR=$(rapids-get-pr-artifact NVIDIA/cuvs "$PR_NUM" cpp conda)
@@ -73,9 +80,6 @@ if [[ "$BRANCH" == pull-request/* ]]; then
   # at runtime and for cmake's find_package (to pick up new C API headers for jextract).
   export LD_LIBRARY_PATH="$LIBCUVS_ARTIFACT_DIR/lib:$LD_LIBRARY_PATH"
   export cuvs_ROOT="$LIBCUVS_ARTIFACT_DIR"
-  # Uninstall the conda libcuvs so the JVM's RPATH (which points to the conda
-  # env's lib dir) cannot find the old libcuvs_c.so ahead of the PR artifact.
-  conda remove --yes --force-remove libcuvs
 fi
 
 rapids-logger "Run Java build"

--- a/ci/build_java.sh
+++ b/ci/build_java.sh
@@ -16,11 +16,6 @@ fi
 # Always build cuvs-java when running the pipeline
 EXTRA_BUILD_ARGS+=("--build-cuvs-java")
 
-# When RAPIDS_BRANCH points at a cuvs pull request, the libcuvs from the conda
-# packages does not contain the PR's changes, so download the pre-built artifact
-# from the PR's CI run instead. Only done in CI, local builds use the conda packages.
-EXTRA_BUILD_ARGS+=("--use-pr-libcuvs")
-
 # shellcheck disable=SC1091
 . /opt/conda/etc/profile.d/conda.sh
 
@@ -64,6 +59,23 @@ if [ -d "$CONDA_PKG_CACHE_DIR" ]; then
 else
   echo "==> Directory '$CONDA_PKG_CACHE_DIR' does not exist. Not updating LD_LIBRARY_PATH"
   exit 1
+fi
+
+# When RAPIDS_BRANCH points at a cuvs PR, the conda packages do not contain the
+# PR's changes, so download the pre-built libcuvs artifact from the PR's own CI run.
+BRANCH=$(cat "RAPIDS_BRANCH")
+if [[ "$BRANCH" == pull-request/* ]]; then
+  PR_NUM="${BRANCH#pull-request/}"
+  rapids-logger "Downloading libcuvs conda artifact from cuvs PR #${PR_NUM}"
+  LIBCUVS_CONDA_DIR=$(rapids-get-pr-artifact NVIDIA/cuvs "$PR_NUM" cpp conda)
+  LIBCUVS_ARTIFACT_DIR=$(rapids-extract-conda-files "$LIBCUVS_CONDA_DIR")
+  # The PR artifact must take precedence over the conda-installed libcuvs both
+  # at runtime and for cmake's find_package (to pick up new C API headers for jextract).
+  export LD_LIBRARY_PATH="$LIBCUVS_ARTIFACT_DIR/lib:$LD_LIBRARY_PATH"
+  export cuvs_ROOT="$LIBCUVS_ARTIFACT_DIR"
+  # Uninstall the conda libcuvs so the JVM's RPATH (which points to the conda
+  # env's lib dir) cannot find the old libcuvs_c.so ahead of the PR artifact.
+  conda remove --yes --force-remove libcuvs
 fi
 
 rapids-logger "Run Java build"


### PR DESCRIPTION
This is a follow up for #181. It ensures that panama-bindings/generate-bindings.sh script is using correct headers (from PR) and tests don't pick up libcuvs that was preinstalled as part of conda environment.