### PR TITLE
enforce 'yamllint' checks, expand changed-files exclusions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@ LICENSE                  @NVIDIA/cuvs-docs-codeowners
 
 # CI code owners
 /.github/                @NVIDIA/adi-ci-codeowners
+/.yamllint.yaml          @rapidsai/ci-codeowners
 /ci/                     @NVIDIA/adi-ci-codeowners
 
 # packaging code owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@ LICENSE                  @NVIDIA/cuvs-docs-codeowners
 
 # CI code owners
 /.github/                @NVIDIA/adi-ci-codeowners
-/.yamllint.yaml          @rapidsai/ci-codeowners
+/.yamllint.yaml          @NVIDIA/adi-ci-codeowners
 /ci/                     @NVIDIA/adi-ci-codeowners
 
 # packaging code owners

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,9 +59,20 @@ jobs:
       files_yaml: |
         test_java:
           - '**'
+          - '!.github/CODEOWNERS'
+          - '!.github/build.yaml'
+          - '!.github/copy-pr-bot.yaml'
+          - '!.github/ops-bot.yaml'
+          - '!.github/release.yml'
+          - '!.gihtub/test.yaml'
+          - '!.github/zizmor.yml'
+          - '!.gitignore'
           - '!.pre-commit-config.yaml'
+          - '!.yamllint.yaml'
           - '!README.md'
           - '!SECURITY.md'
+          - '!ci/check_style.sh'
+          - '!ci/release/update-version.sh'
     permissions:
       actions: read
       contents: read

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,41 +2,54 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
-      - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v6.0.0
-        hooks:
-              - id: check-json
-              - id: trailing-whitespace
-              - id: end-of-file-fixer
-              - id: check-symlinks
-              - id: check-xml
-      - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.5.1
-        hooks:
-          - id: verify-copyright
-            name: verify-copyright
-            args: [--fix, --spdx]
-            files: |
-              (?x)
-                  [.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|rs|java)$|
-                  CMakeLists[.]txt$|
-                  CMakeLists_standalone[.]txt$|
-                  meta[.]yaml$|
-                  dependencies[.]yaml$|
-                  ^[.]pre-commit-config[.]yaml$
-          # TODO: Re-enable once verify-codeowners supports --org parameter
-          # - id: verify-codeowners
-          #   args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
-      - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.21.0
-        hooks:
-            - id: rapids-dependency-file-generator
-              args: ["--clean", "--warn-all", "--strict"]
-      - repo: https://github.com/shellcheck-py/shellcheck-py
-        rev: v0.11.0.1
-        hooks:
-          - id: shellcheck
-      - repo: https://github.com/zizmorcore/zizmor-pre-commit
-        rev: v1.26.1
-        hooks:
-          - id: zizmor
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-json
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-symlinks
+      - id: check-xml
+  - repo: https://github.com/rapidsai/pre-commit-hooks
+    rev: v1.5.1
+    hooks:
+      - id: verify-copyright
+        name: verify-copyright
+        args: [--fix, --spdx]
+        files: |
+          (?x)
+              [.](cmake|cpp|cu|cuh|h|hpp|sh|pxd|py|pyx|rs|java)$|
+              CMakeLists[.]txt$|
+              CMakeLists_standalone[.]txt$|
+              meta[.]yaml$|
+              dependencies[.]yaml$|
+              ^[.]pre-commit-config[.]yaml$
+        # TODO: Re-enable once verify-codeowners supports --org parameter
+        # - id: verify-codeowners
+        #   args: [--fix, --org=NVIDIA, --project-prefix=cuvs-lucene]
+  - repo: https://github.com/rapidsai/dependency-file-generator
+    rev: v1.21.0
+    hooks:
+      - id: rapids-dependency-file-generator
+        args: ["--clean", "--warn-all", "--strict"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        additional_dependencies: [pyyaml]
+        exclude: |
+          (?x)^(
+            [.]github/labeler[.]yml$|
+            conda/environments/.*|
+            cpp/[.]clang-format$|
+            cpp/[.]clang-tidy$|
+            .*xfail\-.*yaml$
+          )
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.26.1
+    hooks:
+      - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
       - id: check-xml
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.6.1
     hooks:
       - id: verify-copyright
         name: verify-copyright
@@ -50,6 +50,6 @@ repos:
             .*xfail\-.*yaml$
           )
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.26.1
+    rev: v1.28.0
     hooks:
       - id: zizmor

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+extends: default
+
+rules:
+  anchors:
+    forbid-undeclared-aliases: true
+    forbid-duplicated-anchors: true
+    forbid-unused-anchors: true
+  braces:
+    forbid: false
+    min-spaces-inside: 0
+    # allow 1 space for jinja templating in conda recipes
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets: enable
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true
+  line-length: disable
+  truthy:
+    allowed-values: ['false', 'true']
+    # having problematic value in keys is rare... and also
+    # GitHub Actions' choie of 'on:' triggers this check
+    # ref: https://github.com/adrienverge/yamllint/issues/430
+    check-keys: false


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/305

Proposes enforcing `yamllint` checks here. My primary motivation is to catch correctness issues in `dependencies.yaml` files, like duplicate entries silently resolving to the last one or indentation mistakes leading to filters being ignored.

But this also has some side benefits for consistency, which makes it a bit easier to write automation.