### PR TITLE
remove hard-coded CI matrices

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,26 +31,30 @@ concurrency:
   cancel-in-progress: true
 permissions: {}
 jobs:
+  conda-java-builds-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
+    with:
+      build_type: pull-request
+      matrix_name: conda-cpp-build
+      matrix_filter: map(select(.ARCH == "amd64"))
   java-build:
+    needs: [conda-java-builds-matrix]
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
-    # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
     strategy:
       fail-fast: false
-      matrix:
-        cuda_version:
-          - '12.9.2'
-          - '13.3.0'
+      matrix: ${{ fromJSON(needs.conda-java-builds-matrix.outputs.matrix) }}
     with:
       build_type: ${{ inputs.build_type || 'branch' }}
       branch: ${{ inputs.branch }}
       arch: "amd64"
       date: ${{ inputs.date }}
-      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
+      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: "ci/build_java.sh"
       file_to_upload: "target/"
-      artifact-name: "cuvs-lucene-cuda${{ matrix.cuda_version }}"
+      artifact-name: "cuvs-lucene-cuda${{ matrix.CUDA_VER }}"
       sha: ${{ inputs.sha }}
     permissions:
       actions: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,7 @@ jobs:
       - check-nightly-ci
       - changed-files
       - checks
+      - conda-java-tests-matrix
       - conda-java-tests
       - telemetry-setup
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,27 +81,30 @@ jobs:
       id-token: write
       packages: read
       pull-requests: read
-  conda-java-tests:
-    needs: [changed-files, checks]
-    secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-    if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_java
-    # Artifacts are not published from these jobs, so it's safe to run for multiple CUDA versions.
-    # If these jobs start producing artifacts, the names will have to differentiate between CUDA versions.
-    strategy:
-      fail-fast: false
-      matrix:
-        cuda_version:
-          - '12.9.2'
-          - '13.3.0'
+  conda-java-tests-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
     with:
       build_type: pull-request
+      matrix_name: conda-cpp-build
+      matrix_filter: map(select(.ARCH == "amd64"))
+  conda-java-tests:
+    needs: conda-java-tests-matrix
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.conda-java-tests-matrix.outputs.matrix) }}
+    with:
+      build_type: pull-request
+      branch: ${{ inputs.branch }}
+      date: ${{ inputs.date }}
+      sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
+      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: "ci/test_java.sh"
-      file_to_upload: "target/"
-      artifact-name: "cuvs-lucene-cuda${{ matrix.cuda_version }}"
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,15 +22,21 @@ on:
         default: nightly
 permissions: {}
 jobs:
+  conda-java-tests-matrix:
+    permissions:
+      contents: read
+    uses: rapidsai/shared-workflows/.github/workflows/compute-matrix.yaml@main
+    with:
+      build_type: ${{ inputs.build_type }}
+      matrix_name: conda-cpp-build
+      matrix_filter: map(select(.ARCH == "amd64"))
   conda-java-tests:
+    needs: conda-java-tests-matrix
     secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     strategy:
       fail-fast: false
-      matrix:
-        cuda_version:
-          - '12.9.2'
-          - '13.3.0'
+      matrix: ${{ fromJSON(needs.conda-java-tests-matrix.outputs.matrix) }}
     with:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
@@ -38,7 +44,7 @@ jobs:
       sha: ${{ inputs.sha }}
       node_type: "gpu-l4-latest-1"
       arch: "amd64"
-      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.cuda_version }}-ubuntu24.04-py3.13"
+      container_image: "rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       script: "ci/test_java.sh"
     permissions:
       actions: read


### PR DESCRIPTION
When `main` flipped from version 26.08 to 26.10, some CI here broke because GitHub Actions configurations had hard-coded references to container images no longer built from https://github.com/rapidsai/ci-imgs. This had to be fixed like this:

* https://github.com/NVIDIA/cuvs-lucene/pull/182
* https://github.com/NVIDIA/cuvs-lucene/pull/179

To avoid that happening again, this proposes changes similar to https://github.com/NVIDIA/cuvs/pull/2340 ... dynamically generating the matrix of supported versions from the shared `rapidsai/shared-workflows` repo.